### PR TITLE
Remove deploy template check for a snapshot

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -302,9 +302,7 @@ public class VSphere {
 		for(int count=0; count<maxTries; count++){
 
 			//get IP
-            Object o = vm.getGuest();
-            String xxx = vm.getGuest().getIpAddress();
-  			if(vm.getGuest().getIpAddress()!=null){
+			if(vm.getGuest().getIpAddress()!=null){
 				return vm.getGuest().getIpAddress();
 			}
 


### PR DESCRIPTION
Hi
I tried to deploy a template to a new VM but it failed as it wanted a snapshot. I don't think you can snapshot a template (certainly not in our version) so I took it out and then it deployed fine.

Regards
Jeremy
