### PR TITLE
ClusterSelection: Get datastores directly from cluster

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -84,7 +84,6 @@ public class Clone extends VSphereBuildStep {
 
 	private boolean cloneFromSource(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws VSphereException {
 		PrintStream jLogger = listener.getLogger();
-		VSphereLogger.vsLogger(jLogger, "Cloning VM. Please wait ...");
 
 		EnvVars env;
 		try {
@@ -94,9 +93,13 @@ public class Clone extends VSphereBuildStep {
 		}
 
 		env.overrideAll(build.getBuildVariables()); // Add in matrix axes..
-		String expandedClone = env.expand(clone), expandedSource = env.expand(sourceName);
 
-		vsphere.cloneVm(expandedClone, expandedSource, linkedClone, resourcePool, cluster, datastore);
+        String expandedClone = env.expand(clone), expandedSource = env.expand(sourceName),
+                expandedCluster = env.expand(cluster), expandedDatastore = env.expand(datastore),
+                expandedResourcePool = env.expand(resourcePool);
+
+		vsphere.cloneVm(expandedClone, expandedSource, linkedClone, expandedResourcePool, expandedCluster,
+                expandedDatastore, jLogger);
 		VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully cloned!");
 
 		return true;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ConvertToVm.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ConvertToVm.java
@@ -77,9 +77,10 @@ public class ConvertToVm extends VSphereBuildStep {
 
 		//TODO:  take in a comma delimited list and convert all
 		env.overrideAll(build.getBuildVariables()); // Add in matrix axis..
-		String expandedTemplate = env.expand(template);
+		String expandedTemplate = env.expand(template), expandedCluster = env.expand(cluster),
+                expandedResourcePool = env.expand(resourcePool);
 
-		vsphere.markAsVm(expandedTemplate, resourcePool, cluster);
+		vsphere.markAsVm(expandedTemplate, expandedResourcePool, expandedCluster);
 		VSphereLogger.vsLogger(jLogger, "\""+expandedTemplate+"\" is a VM!");
 
 		return true;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -87,7 +87,6 @@ public class Deploy extends VSphereBuildStep {
 
 	private boolean deployFromTemplate(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws VSphereException {
 		PrintStream jLogger = listener.getLogger();
-		VSphereLogger.vsLogger(jLogger, "Cloning VM. Please wait ...");
 
 		EnvVars env;
 		try {
@@ -97,16 +96,19 @@ public class Deploy extends VSphereBuildStep {
 		}
 
 		env.overrideAll(build.getBuildVariables()); // Add in matrix axes..
-		String expandedClone = env.expand(clone), expandedTemplate = env.expand(template);
+		String expandedClone = env.expand(clone), expandedTemplate = env.expand(template),
+                expandedCluster = env.expand(cluster), expandedDatastore = env.expand(datastore);
 
-        String resourcePoolName = resourcePool;
+        String resourcePoolName;
         if (resourcePool.length() == 0) {
             // Not all installations are using resource pools. But there is always a hidden "Resources" resource
             // pool, even if not visible in the vSphere Client.
             resourcePoolName = "Resources";
+        } else {
+            resourcePoolName = env.expand(resourcePool);
         }
 
-        vsphere.cloneVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, cluster, datastore);
+        vsphere.cloneVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, jLogger);
 		VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
 
 		return true;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -108,7 +108,7 @@ public class Deploy extends VSphereBuildStep {
             resourcePoolName = env.expand(resourcePool);
         }
 
-        vsphere.cloneVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, jLogger);
+        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, jLogger);
 		VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
 
 		return true;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -14,13 +14,20 @@
  */
 package org.jenkinsci.plugins.vsphere.tools;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.rmi.RemoteException;
-
-import com.vmware.vim25.*;
-import com.vmware.vim25.mo.Datastore;
+import com.vmware.vim25.InvalidProperty;
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.RuntimeFault;
+import com.vmware.vim25.TaskInfoState;
+import com.vmware.vim25.VirtualMachineCloneSpec;
+import com.vmware.vim25.VirtualMachineConfigSpec;
+import com.vmware.vim25.VirtualMachinePowerState;
+import com.vmware.vim25.VirtualMachineQuestionInfo;
+import com.vmware.vim25.VirtualMachineRelocateSpec;
+import com.vmware.vim25.VirtualMachineSnapshotInfo;
+import com.vmware.vim25.VirtualMachineSnapshotTree;
+import com.vmware.vim25.VirtualMachineToolsStatus;
 import com.vmware.vim25.mo.ClusterComputeResource;
+import com.vmware.vim25.mo.Datastore;
 import com.vmware.vim25.mo.Folder;
 import com.vmware.vim25.mo.InventoryNavigator;
 import com.vmware.vim25.mo.ManagedEntity;
@@ -29,8 +36,14 @@ import com.vmware.vim25.mo.ServiceInstance;
 import com.vmware.vim25.mo.Task;
 import com.vmware.vim25.mo.VirtualMachine;
 import com.vmware.vim25.mo.VirtualMachineSnapshot;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import java.io.PrintStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.rmi.RemoteException;
 
 public class VSphere {
 	private final URL url;
@@ -64,75 +77,85 @@ public class VSphere {
 		return (Messages.VSphereLogger_title()+": ").concat(msg);
 	}
 
-	/**
-	 * Creates a new VM from a given template with a given name.
-	 * 
-	 * @param cloneName - name of VM to be created
-	 * @param sourceName - name of VM or template to be cloned
+    /**
+     * Clones a new VM from a given template with a given name.
+     *
+     * @param cloneName - name of VM to be created
+     * @param sourceName - name of VM or template to be cloned
      * @param linkedClone - true if you want to re-use disk backings
      * @param resourcePool - resource pool to use
      * @param cluster - ComputeClusterResource to use
      * @param datastoreName - Datastore to use
      * @throws VSphereException
-	 */
-	public void cloneVm(String cloneName, String sourceName, boolean linkedClone, String resourcePool, String cluster, String datastoreName) throws VSphereException {
+     */
+    public void cloneVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, PrintStream jLogger) throws VSphereException {
 
-		System.out.println("Creating a shallow clone of \""+ sourceName + "\" to \""+cloneName+"\"");
-		try{
-			VirtualMachine sourceVm = getVmByName(sourceName);
+        logMessage(jLogger, "Creating a shallow clone of \""+ sourceName + "\" to \""+cloneName+"\"");
+        try{
+            VirtualMachine sourceVm = getVmByName(sourceName);
 
-			if(sourceVm==null) {
-				throw new VSphereException("No VM or template " + sourceName + " found");
-			}
+            if(sourceVm==null) {
+                throw new VSphereException("VM or template \"" + sourceName + "\" not found");
+            }
 
-			if(getVmByName(cloneName)!=null){
-				throw new VSphereException("VM " + cloneName + " already exists");
-			}
+            if(getVmByName(cloneName)!=null){
+                throw new VSphereException("VM \"" + cloneName + "\" already exists");
+            }
 
-			VirtualMachineRelocateSpec rel  = new VirtualMachineRelocateSpec();
+            VirtualMachineRelocateSpec rel  = new VirtualMachineRelocateSpec();
 
-			if(linkedClone){
-				rel.setDiskMoveType("createNewChildDiskBacking");
-			}else{
-				rel.setDiskMoveType("moveAllDiskBackingsAndDisallowSharing");
-			}
+            if(linkedClone){
+                rel.setDiskMoveType("createNewChildDiskBacking");
+            }else{
+                rel.setDiskMoveType("moveAllDiskBackingsAndDisallowSharing");
+            }
 
             ClusterComputeResource clusterResource = getClusterByName(cluster);
-			rel.setPool(getResourcePoolByName(resourcePool, clusterResource).getMOR());
 
-			VirtualMachineCloneSpec cloneSpec = new VirtualMachineCloneSpec();
-			cloneSpec.setLocation(rel);
-			cloneSpec.setTemplate(false);
-			if (datastoreName != null && !datastoreName.isEmpty()) {
-			    Datastore datastore = getDatastoreByName(datastoreName, clusterResource);
-			    if (datastore==null){
-				System.out.println("Datastore not found!");
-				throw new VSphereException("Datastore not found!");
-			    }
-			    rel.setDatastore(datastore.getMOR());
-			}
+            if (clusterResource == null) {
+                throw new VSphereException("Cluster \"" + cluster + "\" not found");
+            }
 
-			//TODO add config to allow state of VM or snapshot
-			if(sourceVm.getCurrentSnapShot()==null){
-				throw new VSphereException("Source VM or Template \"" + sourceName + "\" requires at least one snapshot!");
-			}
-			cloneSpec.setSnapshot(sourceVm.getCurrentSnapShot().getMOR());
+            ResourcePool resourcePool = getResourcePoolByName(resourcePoolName, clusterResource);
 
-			Task task = sourceVm.cloneVM_Task((Folder) sourceVm.getParent(), 
-					cloneName, cloneSpec);
-			System.out.println("Cloning VM. Please wait ...");
+            if (resourcePool == null) {
+                throw new VSphereException("Resource pool \"" + resourcePoolName + "\" not found");
+            }
 
-			String status = task.waitForTask();
-			if(status==TaskInfoState.success.toString()) {
-				return;
-			}
+            rel.setPool(resourcePool.getMOR());
 
-		}catch(Exception e){
-			throw new VSphereException(e);
-		}
+            VirtualMachineCloneSpec cloneSpec = new VirtualMachineCloneSpec();
+            cloneSpec.setLocation(rel);
+            cloneSpec.setTemplate(false);
+            if (datastoreName != null && !datastoreName.isEmpty()) {
+                Datastore datastore = getDatastoreByName(datastoreName, clusterResource);
+                if (datastore==null){
+                    throw new VSphereException("Datastore \"" + datastoreName + "\" not found!");
+                }
+                rel.setDatastore(datastore.getMOR());
+            }
 
-		throw new VSphereException("Couldn't clone \""+ sourceName +"\"! Does \""+cloneName+"\" already exist?");
-	}
+            //TODO add config to allow state of VM or snapshot
+            if(sourceVm.getCurrentSnapShot()==null){
+                throw new VSphereException("Source VM or Template \"" + sourceName + "\" requires at least one snapshot!");
+            }
+            cloneSpec.setSnapshot(sourceVm.getCurrentSnapShot().getMOR());
+
+            Task task = sourceVm.cloneVM_Task((Folder) sourceVm.getParent(),
+                    cloneName, cloneSpec);
+            logMessage(jLogger, "Started cloning of VM. Please wait ...");
+
+            String status = task.waitForTask();
+            if(!TaskInfoState.success.toString().equals(status)) {
+                throw new VSphereException("Couldn't clone \""+ sourceName +"\"! Does \""+cloneName+"\" already exist? " +
+                        "Clone task ended with status " + status);
+            }
+
+        } catch(Exception e){
+            throw new VSphereException(e);
+        }
+
+    }
 
     public void reconfigureVm(String name, VirtualMachineConfigSpec spec) throws VSphereException {
         VirtualMachine vm = getVmByName(name);
@@ -297,7 +320,7 @@ public class VSphere {
 
 		try {
 			Task task = getVmByName(vmName).createSnapshot_Task(snapshot, description, snapMemory, !snapMemory);
-			if (task.waitForTask()==Task.SUCCESS) {
+			if (task.waitForTask().equals(Task.SUCCESS)) {
 				return;
 			}
 		} catch (Exception e) {
@@ -397,10 +420,13 @@ public class VSphere {
 	}
 
 
-    private Datastore getDatastoreByName(final String datastoreName, ManagedEntity rootEntity) throws RemoteException, MalformedURLException {
-        if (rootEntity==null) rootEntity=getServiceInstance().getRootFolder();
-
-        return (Datastore) new InventoryNavigator(rootEntity).searchManagedEntity("Datastore", datastoreName);
+    private Datastore getDatastoreByName(final String datastoreName, ClusterComputeResource clusterResource) throws RemoteException, MalformedURLException {
+        for (Datastore dataStore : clusterResource.getDatastores()) {
+            if (dataStore.getName().equals(datastoreName)) {
+                return dataStore;
+            }
+        }
+        return null;
     }
 
 	/**
@@ -490,7 +516,7 @@ public class VSphere {
             }
 
 			String status = vm.destroy_Task().waitForTask();
-			if(status==Task.SUCCESS)
+			if(status.equals(Task.SUCCESS))
 			{
 				System.out.println("VM was deleted successfully.");
 				return;
@@ -604,7 +630,7 @@ public class VSphere {
                     System.out.println("Powering off the VM");
                     status = vm.powerOffVM_Task().waitForTask();
 
-                    if(status==Task.SUCCESS) {
+                    if(status.equals(Task.SUCCESS)) {
                         System.out.println("VM was powered down successfully.");
                         return;
                     }
@@ -632,7 +658,7 @@ public class VSphere {
 				throw new VSphereException(e);
 			}
 
-			if(status==Task.SUCCESS) {
+			if(Task.SUCCESS.equals(status)) {
 				System.out.println("VM was suspended successfully.");
 				return;
 			}
@@ -644,4 +670,12 @@ public class VSphere {
 
 		throw new VSphereException("Machine could not be suspended!");
 	}
+
+    private void logMessage(PrintStream jLogger, String message) {
+        if (jLogger != null) {
+            VSphereLogger.vsLogger(jLogger, message);
+        } else {
+            System.out.println(message);
+        }
+    }
 }


### PR DESCRIPTION
In our Vsphere setup, searching for Datastores under the cluster doesn't work.
When calling getDataStoreClusters on a cluster, the cluster is found though.
Unfortunately I don't know enough about the vmware vim25 api to know why the
datastore wasn't found.
It is found if I don't pass in the cluster for the searching and the searching
takes  place on the root entity.
Pass in logger to Vsphere clone method so that output can be seen in jenkins
console.

While testing this I realized that several arguments are not expanded.
Cluster for instance is not expanded in either Clone or Deploy.
This would mean that ${CLUSTER} for instance wouldn't be expanded.
Improved logging messaging as well so errors in configuration are easier to find.