### PR TITLE
VsphereSelection: Allow dynamic selection of vsphere cloud

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
@@ -71,7 +71,7 @@ public abstract class VSphereBuildStep implements Describable<VSphereBuildStep>,
 					}
 				}
 			}
-			throw new RuntimeException(Messages.validation_instanceNotFound());
+			throw new RuntimeException(Messages.validation_instanceNotFound(serverName));
 		}
 
 		public static vSphereCloud getVSphereCloudByHash(int hash) throws RuntimeException, VSphereException {

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer/help-serverName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer/help-serverName.html
@@ -1,3 +1,3 @@
 <div>
-  The vSphere configuration to use.
+  The vSphere configuration to use. Use ${VSPHERE_CLOUD_NAME} and create a matching parameter if you want to dynamically select the vSphere configuration.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Messages.properties
@@ -39,4 +39,4 @@ console.buildStepStart=Performing vSphere build step: "{0}"
 console.usingServerConfig=Attempting to use server configuration: "{0}"
 
 validation.serverExistence=Server does not exist in global config! Please re-save your job configuration.
-validation.instanceNotFound=Could not find our vSphere Cloud instance!
+validation.instanceNotFound=Could not find vSphere Cloud instance "{0}"!


### PR DESCRIPTION
A jenkins user could have a job that can be used for two separate VSphere
instances.
At present there is no way to select the vsphere instance using a build parameter.
This adds a parameter called ${VSPHERE_CLOUD_NAME} as an vsphere cloud option for selection.
If selected then the jenkins user can add a parameter of the same name for the
build.