### PR TITLE
Disconnect vsphere

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -290,7 +290,7 @@ public class vSphereCloud extends Cloud {
                     return FormValidation.error("Password is not specified");
                 }
 
-                VSphere.connect(vsHost + "/sdk", effectiveUsername, effectivePassword);
+                VSphere.connect(vsHost + "/sdk", effectiveUsername, effectivePassword).disconnect();
                 
                 return FormValidation.ok("Connected successfully");
             } catch (Exception e) {

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -137,6 +137,7 @@ public class vSphereCloudLauncher extends ComputerLauncher {
 
                 vSphereCloud vsC = findOurVsInstance();
                 vsSlave.slaveIsStarting = Boolean.TRUE;
+                VSphere v = null;
                 try {
                     vSphereCloud.Log(slaveComputer, taskListener, "Starting Virtual Machine...");
 
@@ -144,7 +145,7 @@ public class vSphereCloudLauncher extends ComputerLauncher {
                     cal.add(Calendar.MINUTE, 5);
                     vSphereCloudSlave.AddProbableLaunch(vsSlave, cal.getTime());
 
-                    VSphere v = vsC.vSphereInstance();
+                    v = vsC.vSphereInstance();
                     VirtualMachine vm = v.getVmByName(vmName);
                     if (vm == null) {
                         throw new IOException("Virtual Machine could not be found");
@@ -220,6 +221,8 @@ public class vSphereCloudLauncher extends ComputerLauncher {
                 } finally {
                     vSphereCloudSlave.RemoveProbableLaunch(vsSlave);
                     vsSlave.slaveIsStarting = Boolean.FALSE;
+                    if (v != null)
+                        v.disconnect();
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -246,70 +246,67 @@ public class vSphereCloudLauncher extends ComputerLauncher {
             return;
         }
         
-        if (slaveComputer.isOnline()) {
-
-            vsSlave.slaveIsDisconnecting = Boolean.TRUE;
-            VSphere v = null;
-            try {
-                vSphereCloud.Log(slaveComputer, taskListener, "Running disconnect procedure...");
-                delegate.afterDisconnect(slaveComputer, taskListener);
-                vSphereCloud.Log(slaveComputer, taskListener, "Shutting down Virtual Machine...");
-                MACHINE_ACTION localIdle = idleAction;
-                if (localIdle == null) {
-                    localIdle = MACHINE_ACTION.SHUTDOWN;
-                }
-                vSphereCloud vsC = findOurVsInstance();
-                vsC.markVMOffline(slaveComputer.getDisplayName(), vmName);
-                v = vsC.vSphereInstance();
-                VirtualMachine vm = v.getVmByName(vmName);
-                if ((vm != null) && (localIdle != MACHINE_ACTION.NOTHING)) {
-                    //VirtualMachinePowerState power = vm.getRuntime().getPowerState();
-                    VirtualMachinePowerState power = vm.getSummary().getRuntime().powerState;
-                    if (power == VirtualMachinePowerState.poweredOn) {
-                        switch (localIdle) {
-                            case SHUTDOWN:
-                            case REVERT:
-                            case REVERT_AND_RESET:
-                            case REVERT_AND_RESTART:
-                                shutdownVM(vm, slaveComputer, taskListener);
-                                break;
-                            case SUSPEND:
-                                suspendVM(vm, slaveComputer, taskListener);
-                                break;
-                            case RESET:
-                                resetVM(vm, slaveComputer, taskListener);
-                                break;
-                        }
-                        if (localIdle == MACHINE_ACTION.REVERT) {
-                            revertVM(vm, vsC, slaveComputer, taskListener);
-                        } else if (localIdle == MACHINE_ACTION.REVERT_AND_RESTART) {
-                            revertVM(vm, vsC, slaveComputer, taskListener);
-                            if (power == VirtualMachinePowerState.poweredOn) {
-                                 // Some time is needed for the VMWare Tools to reactivate
-                                Thread.sleep(60000);
-                                shutdownVM(vm, slaveComputer, taskListener);
-                            }
-                            powerOnVM(vm, slaveComputer, taskListener);
-                        } else if (localIdle == MACHINE_ACTION.REVERT_AND_RESET) {
-                            revertVM(vm, vsC, slaveComputer, taskListener);
-                            resetVM(vm, slaveComputer, taskListener);
-                        }
-                    } else {
-                            // VM is already powered down.
-                    }
-                }
-                if (v != null)
-                    v.disconnect();
-            } catch (Throwable t) {
-                vSphereCloud.Log(slaveComputer, taskListener, "Got an exception");
-                vSphereCloud.Log(slaveComputer, taskListener, t.toString());
-                vSphereCloud.Log(slaveComputer, taskListener, "Printed exception");
-                taskListener.fatalError(t.getMessage(), t);
-            } finally {
-                vsSlave.slaveIsDisconnecting = Boolean.FALSE;
-                vsSlave.doingLastInLimitedTestRun = Boolean.FALSE;
-                vsSlave.slaveIsStarting = Boolean.FALSE;
+        vsSlave.slaveIsDisconnecting = Boolean.TRUE;
+        VSphere v = null;
+        try {
+            vSphereCloud.Log(slaveComputer, taskListener, "Running disconnect procedure...");
+            delegate.afterDisconnect(slaveComputer, taskListener);
+            vSphereCloud.Log(slaveComputer, taskListener, "Shutting down Virtual Machine...");
+            MACHINE_ACTION localIdle = idleAction;
+            if (localIdle == null) {
+                localIdle = MACHINE_ACTION.SHUTDOWN;
             }
+            vSphereCloud vsC = findOurVsInstance();
+            vsC.markVMOffline(slaveComputer.getDisplayName(), vmName);
+            v = vsC.vSphereInstance();
+            VirtualMachine vm = v.getVmByName(vmName);
+            if ((vm != null) && (localIdle != MACHINE_ACTION.NOTHING)) {
+                //VirtualMachinePowerState power = vm.getRuntime().getPowerState();
+                VirtualMachinePowerState power = vm.getSummary().getRuntime().powerState;
+                if (power == VirtualMachinePowerState.poweredOn) {
+                    switch (localIdle) {
+                        case SHUTDOWN:
+                        case REVERT:
+                        case REVERT_AND_RESET:
+                        case REVERT_AND_RESTART:
+                            shutdownVM(vm, slaveComputer, taskListener);
+                            break;
+                        case SUSPEND:
+                            suspendVM(vm, slaveComputer, taskListener);
+                            break;
+                        case RESET:
+                            resetVM(vm, slaveComputer, taskListener);
+                            break;
+                    }
+                    if (localIdle == MACHINE_ACTION.REVERT) {
+                        revertVM(vm, vsC, slaveComputer, taskListener);
+                    } else if (localIdle == MACHINE_ACTION.REVERT_AND_RESTART) {
+                        revertVM(vm, vsC, slaveComputer, taskListener);
+                        if (power == VirtualMachinePowerState.poweredOn) {
+                             // Some time is needed for the VMWare Tools to reactivate
+                            Thread.sleep(60000);
+                            shutdownVM(vm, slaveComputer, taskListener);
+                        }
+                        powerOnVM(vm, slaveComputer, taskListener);
+                    } else if (localIdle == MACHINE_ACTION.REVERT_AND_RESET) {
+                        revertVM(vm, vsC, slaveComputer, taskListener);
+                        resetVM(vm, slaveComputer, taskListener);
+                    }
+                } else {
+                        // VM is already powered down.
+                }
+            }
+            if (v != null)
+                v.disconnect();
+        } catch (Throwable t) {
+            vSphereCloud.Log(slaveComputer, taskListener, "Got an exception");
+            vSphereCloud.Log(slaveComputer, taskListener, t.toString());
+            vSphereCloud.Log(slaveComputer, taskListener, "Printed exception");
+            taskListener.fatalError(t.getMessage(), t);
+        } finally {
+            vsSlave.slaveIsDisconnecting = Boolean.FALSE;
+            vsSlave.doingLastInLimitedTestRun = Boolean.FALSE;
+            vsSlave.slaveIsStarting = Boolean.FALSE;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
@@ -69,8 +69,11 @@ public class VSphereBuildStepContainer extends Builder {
 			//TODO - also need to improve logging here.
 			VSphere vsphere = VSphereBuildStep.VSphereBuildStepDescriptor.getVSphereCloudByHash(this.serverHash).vSphereInstance(); 
 			buildStep.setVsphere(vsphere);
+                        
+                        Boolean buildStepResult = buildStep.perform(build, launcher, listener);
+                        vsphere.disconnect();
 
-			return buildStep.perform(build, launcher, listener);
+			return buildStepResult;
 		} catch (Exception e) {
 			VSphereLogger.vsLogger(listener.getLogger(), e.getMessage());
 		}

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -59,6 +59,17 @@ public class VSphere {
 	public static VSphere connect(@Nonnull String server, @Nonnull String user, @CheckForNull String pw) throws VSphereException {
 		return new VSphere(server, user, pw);
 	}
+        
+        /**
+         * Disconnect from vSphere server
+         */
+        public void disconnect() {
+            try {
+                this.getServiceInstance().getServerConnection().logout();
+            } catch (Exception e) {
+                System.out.println("Caught exception when trying to disconnect vSphere." + String.format("%n") + e);
+            }
+        }
 
 	public static String vSphereOutput(String msg){
 		return (Messages.VSphereLogger_title()+": ").concat(msg);


### PR DESCRIPTION
Our vCenter admins observed that there were simply too many open / idle sessions on vCenter using the login provided to Jenkins vSphere cloud plugin. This set of changes attempts to disconnect from the vCenter after whatever work was needed to be done.