### PR TITLE
HelpDoc: Set correct name for ip address variable

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/help-envVariablePrefix.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/help-envVariablePrefix.html
@@ -1,3 +1,3 @@
 <div>
-  Prefix for guest info environmental variables. E.g. for prefix VM1, variables would be VM1_IP, VM1_HostName etc.
+  Prefix for guest info environmental variables. E.g. for prefix VM1, variables would be VM1_IpAddress, VM1_HostName etc.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/help-vm.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/help-vm.html
@@ -1,5 +1,5 @@
 <div>
   The name of the VM to expose guest info for.<br/>
-  Variables IP, Hostname, ToolsStatus, ToolsRunningStatus, ToolsVersion, ToolsVersionStatus, GuestState, GuestId,
+  Variables IpAddress, Hostname, ToolsStatus, ToolsRunningStatus, ToolsVersion, ToolsVersionStatus, GuestState, GuestId,
   GuestFamily, GuestFullName, AppHeartbeatStatus, GuestOperationsReady, InteractiveGuestOperationsReady are exposed.
 </div>


### PR DESCRIPTION
I missed changing the IP variable name is IpAddress.
Updated to avoid showing user the incorrect variable name.