### PR TITLE
SelectableCloud: Cloud should be selectable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -4,6 +4,7 @@
  */
 package org.jenkinsci.plugins;
 
+import hudson.model.Hudson;
 import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
 import hudson.Extension;
 import hudson.Util;
@@ -18,9 +19,11 @@ import hudson.util.FormValidation;
 import hudson.util.Scrambler;
 import java.io.IOException;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -225,6 +228,24 @@ public class vSphereCloud extends Cloud {
         EnsureLists();
         if (currentOnline.remove(slaveName) != null)
             currentOnlineSlaveCount--;
+    }
+
+    public static List<vSphereCloud> findAllVsphereClouds() {
+        List<vSphereCloud> vSphereClouds = new ArrayList<vSphereCloud>();
+        for (Cloud cloud : Hudson.getInstance().clouds) {
+            if (cloud instanceof vSphereCloud) {
+                vSphereClouds.add((vSphereCloud) cloud);
+            }
+        }
+        return vSphereClouds;
+    }
+
+    public static List<String> finaAllVsphereCloudNames() {
+        List<String> cloudNames = new ArrayList<String>();
+        for (vSphereCloud vSphereCloud : findAllVsphereClouds()) {
+            cloudNames.add(vSphereCloud.getVsDescription());
+        }
+        return cloudNames;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -87,11 +87,9 @@ public class vSphereCloudLauncher extends ComputerLauncher {
 
     public vSphereCloud findOurVsInstance() throws RuntimeException {
         if (vsDescription != null && vmName != null) {
-            vSphereCloud vs = null;
-            for (Cloud cloud : Hudson.getInstance().clouds) {
-                if (cloud instanceof vSphereCloud && ((vSphereCloud) cloud).getVsDescription().equals(vsDescription)) {
-                    vs = (vSphereCloud) cloud;
-                    return vs;
+            for (vSphereCloud cloud : vSphereCloud.findAllVsphereClouds()) {
+                if (cloud.getVsDescription().equals(vsDescription)) {
+                    return cloud;
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
@@ -65,9 +65,9 @@ public abstract class VSphereBuildStep implements Describable<VSphereBuildStep>,
 
 		public static vSphereCloud getVSphereCloudByName(String serverName) throws RuntimeException, VSphereException {
 			if (serverName != null){
-				for (Cloud cloud : Hudson.getInstance().clouds) {
-					if (cloud instanceof vSphereCloud && ((vSphereCloud) cloud).getVsDescription().equals(serverName)) {
-						return (vSphereCloud) cloud;
+				for (vSphereCloud cloud : vSphereCloud.findAllVsphereClouds()) {
+					if (cloud.getVsDescription().equals(serverName)) {
+						return cloud;
 					}
 				}
 			}
@@ -75,9 +75,9 @@ public abstract class VSphereBuildStep implements Describable<VSphereBuildStep>,
 		}
 
 		public static vSphereCloud getVSphereCloudByHash(int hash) throws RuntimeException, VSphereException {
-			for (Cloud cloud : Hudson.getInstance().clouds) {
-				if (cloud instanceof vSphereCloud && ((vSphereCloud) cloud).getHash()==hash ){
-					return (vSphereCloud) cloud;
+			for (vSphereCloud cloud : vSphereCloud.findAllVsphereClouds()) {
+				if (cloud.getHash()==hash ){
+					return cloud;
 				}
 			}
 			throw new RuntimeException(Messages.validation_serverExistence());

--- a/src/main/java/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter.java
@@ -1,0 +1,72 @@
+package org.jenkinsci.plugins.vsphere.parameters;
+
+import hudson.Extension;
+import hudson.model.ParameterValue;
+import hudson.model.SimpleParameterDefinition;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+import hudson.util.ListBoxModel;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.vSphereCloud;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.export.Exported;
+
+import java.util.List;
+
+/**
+ * Parameter used for selecting a vSphere cloud from a dropdown box.
+ */
+public class CloudSelectorParameter extends SimpleParameterDefinition {
+
+    @DataBoundConstructor
+    public CloudSelectorParameter() {
+        super("VSPHERE_CLOUD_NAME", "Vsphere Cloud Selector");
+    }
+
+    @Override
+    public StringParameterValue getDefaultParameterValue() {
+        List<String> cloudNames = vSphereCloud.finaAllVsphereCloudNames();
+        return new StringParameterValue(getName(), cloudNames.get(0), getDescription());
+    }
+
+    private StringParameterValue checkValue(StringParameterValue value) {
+        List<String> cloudNames = vSphereCloud.finaAllVsphereCloudNames();
+        if (!cloudNames.contains(value.value))
+            throw new IllegalArgumentException("No vsphere cloud with name: " + value.value);
+        return value;
+    }
+
+    @Override
+    public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
+        StringParameterValue value = req.bindJSON(StringParameterValue.class, jo);
+        value.setDescription(getDescription());
+        return checkValue(value);
+    }
+
+    public StringParameterValue createValue(String value) {
+        return checkValue(new StringParameterValue(getName(), value, getDescription()));
+    }
+
+    @Exported
+    public List<String> getCloudNames() {
+        return vSphereCloud.finaAllVsphereCloudNames();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ParameterDescriptor {
+
+        public ListBoxModel doFillCloudNameItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (String cloudName : vSphereCloud.finaAllVsphereCloudNames()) {
+                items.add(cloudName);
+            }
+            return items;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.VSphere_title_vSphereCloudSelectorParameter();
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer/help-serverName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer/help-serverName.html
@@ -1,3 +1,4 @@
 <div>
-  The vSphere configuration to use. Use ${VSPHERE_CLOUD_NAME} and create a matching parameter if you want to dynamically select the vSphere configuration.
+  The vSphere configuration to use. Use ${VSPHERE_CLOUD_NAME} and create a vsphere selection parameter if you want to dynamically select the vSphere configuration.<br/>
+  A vsphere selection parameter is the same as a string parameter named VSPHERE_CLOUD_NAME but allows easy selection of a vsphere cloud.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/config.jelly
@@ -1,0 +1,17 @@
+<!--
+Copyright 2013, MANDIANT, Eric Lordahl
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" />

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/index.jelly
@@ -1,0 +1,29 @@
+<!--
+Copyright 2013, MANDIANT, Eric Lordahl
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="VSPHERE_CLOUD_NAME">
+        <div name="parameter">
+            <input type="hidden" name="name" value="${it.name}" />
+            <select name="value">
+                <j:forEach var="value" items="${it.cloudNames}">
+                    <f:option selected="${it.value==value}">${value}</f:option>
+                </j:forEach>
+            </select>
+        </div>
+    </f:entry>
+</j:jelly>
+

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/Messages.properties
@@ -1,0 +1,1 @@
+VSphere.title.vSphereCloudSelectorParameter=vSphere Cloud Selection Parameter


### PR DESCRIPTION
Provides a UI parameter for easy selecting of a cloud from all existing Vsphere clouds.
The selected cloud is equivalent to a string parameter named VSPHERE_CLOUD_NAME.
To use that selected cloud, a vsphere build step should set it's cloud name to VSPHERE_CLOUD_NAME.