### PR TITLE
JENKINS-27305: Add support for distributed vswitches

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -48,6 +48,10 @@ import com.vmware.vim25.mo.ServiceInstance;
 import com.vmware.vim25.mo.Task;
 import com.vmware.vim25.mo.VirtualMachine;
 import com.vmware.vim25.mo.VirtualMachineSnapshot;
+import com.vmware.vim25.mo.Datacenter;
+import com.vmware.vim25.mo.Network;
+import com.vmware.vim25.mo.DistributedVirtualPortgroup;
+import com.vmware.vim25.mo.DistributedVirtualSwitch;
 
 public class VSphere {
 	private final URL url;
@@ -756,6 +760,99 @@ public class VSphere {
 		}
 
 		throw new VSphereException("Machine could not be suspended!");
+	}
+
+	/**
+	 * Private helper functions that finds the datanceter a VirtualMachine belongs to
+	 * @param managedEntity - VM object
+	 * @return returns Datacenter object
+	 */
+	private Datacenter getDataCenter(ManagedEntity managedEntity)
+	{
+		if (managedEntity != null) {
+			ManagedEntity parent = managedEntity.getParent();
+			if (parent.getMOR().getType().equals("Datacenter")) {
+				return (Datacenter) parent;
+			} else {
+				return getDataCenter(managedEntity.getParent());
+			}
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Find Distributed Virtual Port Group name in the same Datacenter as the VM
+	 * @param virtualMachine - VM object
+	 * @param name - the name of the Port Group
+	 * @return returns DistributedVirtualPortgroup object for the provided vDS PortGroup
+	 * @throws VSphereException
+	 */
+	public Network getNetworkPortGroupByName(VirtualMachine virtualMachine,
+														String name) throws VSphereException
+	{
+		try {
+			Datacenter datacenter = getDataCenter(virtualMachine);
+			for (Network network : datacenter.getNetworks())
+			{
+				if (network instanceof Network &&
+						(name.isEmpty() || network.getName().contentEquals(name)))
+				{
+					return network;
+				}
+			}
+		} catch (Exception e) {
+			throw new VSphereException(e);
+		}
+		return null;
+	}
+
+	/**
+	 * Find Distributed Virtual Port Group name in the same Datacenter as the VM
+	 * @param virtualMachine - VM object
+	 * @param name - the name of the Port Group
+	 * @return returns DistributedVirtualPortgroup object for the provided vDS PortGroup
+	 * @throws VSphereException
+	 */
+	public DistributedVirtualPortgroup getDistributedVirtualPortGroupByName(VirtualMachine virtualMachine,
+																			 String name) throws VSphereException
+	{
+		try {
+			Datacenter datacenter = getDataCenter(virtualMachine);
+			for (Network network : datacenter.getNetworks())
+			{
+				if (network instanceof DistributedVirtualPortgroup &&
+						(name.isEmpty() || network.getName().contentEquals(name)))
+				{
+					return (DistributedVirtualPortgroup)network;
+				}
+			}
+		} catch (Exception e) {
+			throw new VSphereException(e);
+		}
+		return null;
+	}
+
+	/**
+	 * Find Distributed Virtual Switch from the provided Distributed Virtual Portgroup
+	 * @param distributedVirtualPortgroup - DistributedVirtualPortgroup object for the provided vDS PortGroup
+	 * @return returns DistributedVirtualSwitch object that represents the vDS Switch
+	 * @throws VSphereException
+	 */
+	public DistributedVirtualSwitch getDistributedVirtualSwitchByPortGroup(
+			DistributedVirtualPortgroup distributedVirtualPortgroup) throws VSphereException
+	{
+		try
+		{
+			ManagedObjectReference managedObjectReference = new ManagedObjectReference();
+			managedObjectReference.setType("DistributedVirtualSwitch");
+			managedObjectReference.setVal(distributedVirtualPortgroup.getConfig().getDistributedVirtualSwitch().getVal());
+			return new DistributedVirtualSwitch(getServiceInstance().getServerConnection(), managedObjectReference);
+		}
+		catch (Exception e)
+		{
+			throw new VSphereException(e);
+		}
 	}
 
     private void logMessage(PrintStream jLogger, String message) {

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Messages.properties
@@ -14,6 +14,7 @@ vm.title.ReconfigureNetworkAdapter=Edit Network Adapter
 vm.title.ReconfigureCpu=Edit CPU
 vm.title.ReconfigureMemory=Edit Memory
 vm.title.ReconfigureDisk=Add a disk
+vm.title.ReconfigureAnnotation=Add an annotation
 vm.title.Rename=Rename VM
 vm.title.RenameSnapshot=Rename Snapshot
 vm.title.TakeSnapshot=Take Snapshot
@@ -41,3 +42,4 @@ console.usingServerConfig=Attempting to use server configuration: "{0}"
 
 validation.serverExistence=Server does not exist in global config! Please re-save your job configuration.
 validation.instanceNotFound=Could not find vSphere Cloud instance "{0}"!
+validation.wrongSwitchSelection=Cannot configure both Standard Switch and Distributed Switch for the same network device

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters/config.jelly
@@ -30,7 +30,28 @@ limitations under the License.
         <f:textbox  />
     </f:entry>
 
-    <f:entry title="${%Network Port Group}" field="portGroup">
-        <f:textbox  />
-    </f:entry>
+    <f:block>
+        <table>
+            <f:optionalBlock name="standardSwitch" title="Configure VMWare Standard Switch"
+                             inline="true" checked="${instance.standardSwitch}">
+                <f:entry title="${%Network Port Group}" field="portGroup">
+                    <f:textbox  />
+                </f:entry>
+            </f:optionalBlock>
+        </table>
+    </f:block>
+
+    <f:block>
+        <table>
+            <f:optionalBlock name="distributedSwitch" title="Configure VMWare Distributed Switch"
+                             inline="true" checked="${instance.distributedSwitch}">
+                <f:entry title="${%Distributed Port Group}" field="distributedPortGroup">
+                    <f:textbox  />
+                </f:entry>
+                <f:entry title="${%Distributed Port ID}" field="distributedPortId">
+                    <f:textbox  />
+                </f:entry>
+            </f:optionalBlock>
+        </table>
+    </f:block>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters/help-distributedPortGroup.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters/help-distributedPortGroup.html
@@ -1,0 +1,3 @@
+<div>
+  Specifies the Distributed Switch Port Group.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters/help-distributedPortId.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters/help-distributedPortId.html
@@ -1,0 +1,3 @@
+<div>
+  Port Id to be used from the specified Distributed Switch Port Group.
+</div>


### PR DESCRIPTION
I added support for distributed switches a few month ago and wanted to create a pull request, than saw that there is another pull request, which in my eyes is implements it much better. So this pull request contains all the changes from **https://github.com/jenkinsci/vsphere-cloud-plugin/pull/36** (without the "ability to choose if to power-on the machine after clone and deploy"). This code is from **romanblachman** it just contains all changes till now.