### PR TITLE
Continue with the disconnection procedure if temporarily offline flag…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -243,8 +243,10 @@ public class vSphereCloudLauncher extends ComputerLauncher {
             return;
         }
         if (slaveComputer.isTemporarilyOffline()) {
-            vSphereCloud.Log(slaveComputer, taskListener, "Not disconnecting VM because it's not accepting tasks");
-            return;
+            if (!slaveComputer.getOfflineCauseReason().contains("vSphere Plugin")) {
+                vSphereCloud.Log(slaveComputer, taskListener, "Not disconnecting VM because it's not accepting tasks");
+                return;
+            }
         }
         
         vsSlave.slaveIsDisconnecting = Boolean.TRUE;


### PR DESCRIPTION
… was set by the plugin.

The following two options did not work together: 
-Disconnect after Limited Builds: 1 
-What to do when the slave is disconnected: Revert and Reset 
The plugin set the temporarily offline flag in the method vSphereCloudSlave.EndLimitedTestRun, and the revert and reset from method vSphereCloudLauncher.afterDisconnect was not running because the flag was set. 
