### PR TITLE
Fix for https://issues.jenkins-ci.org/browse/JENKINS-38030

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
@@ -1,24 +1,27 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">    
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry>
         <f:property field="vsConnectionConfig"/>
     </f:entry>
     <f:entry title="${%Name to use for this vSphere Cloud}" field="vsDescription">
-        <f:textbox />
+        <f:textbox/>
     </f:entry>
- 
+
     <f:advanced>
-        <f:entry title="${%Max number of slaves online}" field="maxOnlineSlaves">
-            <f:textbox clazz="required number" />
+        <f:entry title="${%Max number of virtual machines online}" field="maxOnlineSlaves" description="0 means unlimited.">
+            <f:textbox clazz="required number"/>
         </f:entry>
-        <f:entry title="${%Instance Cap}" field="instanceCap" description="Instance Cap of 0 is the same a unlimited.">
+        <f:entry title="${%Template Instance Cap}" field="instanceCap" description="0 means unlimited.">
             <f:textbox clazz="required number" default="0"/>
         </f:entry>
     </f:advanced>
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="vsHost,vsDescription,credentialsId"/>
-    
-    <f:entry title="${%Slave Templates}"  description="${%List of Master VMs to be cloned as slaves}">
-        <f:repeatable field="templates">
+
+    <f:entry title="${%Templates}" description="${%List of Master VMs to be cloned as slaves}">
+        <f:repeatable field="templates" add="${%Add vSphere Template}">
             <st:include page="config.jelly" class="${descriptor.clazz}"/>
+            <div align="right">
+                <f:repeatableDeleteButton value="${%Delete vSphere Template}"/>
+            </div>
         </f:repeatable>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-instanceCap.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-instanceCap.html
@@ -1,0 +1,5 @@
+<div>
+Maximum number of template slave instance virtual machines that this vSphere Cloud should use at one time.<br/>
+A value of 0 indicates no maximum value.<br/>
+This limit applies only to machines started as a result of vSphere Template slaves (defined below).
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-maxOnlineSlaves.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-maxOnlineSlaves.html
@@ -1,1 +1,7 @@
-<div>Maximum number of virtual machines that this vSphere Cloud should use at one time. A value of 0 indicates no maximum value.</div>
+<div>
+Maximum number of virtual machines that this vSphere Cloud may use at one time.<br/>
+A value of 0 indicates no maximum value.<br/>
+If there are more VMs running (in total - not just ones started by the vSphere plugin)
+than the maximum then the vSphere Cloud plug-in will not
+start up further VMs.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -1,63 +1,63 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-    <table wdith="100%">
+    <table width="100%">
         <f:entry title="${%Clone Name Prefix}" field="cloneNamePrefix">
             <f:textbox/>
         </f:entry>
-        
+
         <f:entry title="${%Master Image Name}" field="masterImageName">
             <f:textbox/>
         </f:entry>
-    
+
         <f:entry title="${%Snapshot Name}" field="snapshotName">
             <f:textbox/>
         </f:entry>
-        
+
         <f:entry title="${%Linked Clone}" field="linkedClone">
             <f:checkbox/>
         </f:entry>
-    
+
         <f:entry title="${%Cluster}" field="cluster">
             <f:textbox/>
         </f:entry>
-        
+
         <f:entry title="${%Resource Pool}" field="resourcePool">
             <f:textbox/>
         </f:entry>
-    
+
         <f:entry title="${%Datastore}" field="datastore">
             <f:textbox/>
         </f:entry>
-    
+
         <f:entry title="${%Description}" field="templateDescription">
             <f:textbox/>
         </f:entry>
-    
+
         <f:entry title="${%Instance Cap}" field="templateInstanceCap" description="The maximum number of clones to make of this master.  0 = unlimited">
             <f:textbox clazz="requiered number" default="0"/>
         </f:entry>
-    
+
         <f:entry title="${%# of Executors}" field="numberOfExecutors">
             <f:textbox clazz="required number" default="1"/>
         </f:entry>
-    
+
         <f:entry title="${%Remote FS Root}" field="remoteFS">
             <f:textbox/>
         </f:entry>
-    
+
         <f:entry title="${%Labels}" field="labelString">
             <f:textbox/>
         </f:entry>
-    
+
         <f:slave-mode name="mode" node="${it}"/>
 
         <f:entry title="${%Force VM Launch}" field="forceVMLaunch" description="${%VMs can always be switched on, even if direct support is missing in the secondary launch option.}">
             <f:checkbox/>
         </f:entry>
-    
+
         <f:entry title="${%Wait for VMTools}" field="waitForVMTools" description="${%Wait for VMTools in the VM to start up.}">
             <f:checkbox/>
         </f:entry>
-    
+
         <f:entry title="${%Delay between launch and boot complete}" field="launchDelay" description="${%How many seconds between the VM being brought back to life before Jenkins can connect and bring it online as slave.}">
             <f:textbox clazz="required number" default="60"/>
         </f:entry>
@@ -65,11 +65,11 @@
         <f:entry title="${%Disconnect After Limited Builds}" field="limitedRunCount" description="${%Number of builds to allow before disconnecting the agent; use 0 for NEVER.}">
             <f:textbox clazz="requiered number" default="1"/>        
         </f:entry>
-            
+
         <f:entry title="${%Clone's user}" field="credentialsId">
             <c:select/>
         </f:entry>
-    
+
         <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties"/>
     </table>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-cloneNamePrefix.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-cloneNamePrefix.html
@@ -1,0 +1,6 @@
+<div>
+Controls the name by which the virtual machine will be known to vSphere.
+The plug-in will append an underscore and a random UUID to this prefix in order to generate unique names.<p>
+Note: You must ensure that no virtual machines (other than those created by this template) have names starting with this prefix.
+</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-masterImageName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-masterImageName.html
@@ -1,0 +1,3 @@
+<div>
+Name of the virtual machine as it appears in vSphere.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-snapshotName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-snapshotName.html
@@ -1,0 +1,3 @@
+<div>
+OPTIONAL - the name of a snapshot of the virtual machine.
+</div>


### PR DESCRIPTION
Added delete button to vSphere cloud UI to delete a slave template.
Cosmetic tweaks to vSphere cloud UI.
Added help text for vSphere cloud fields instanceCap, cloneNamePrefix,
masterImageName, snapshotName.
Added to help text for vSphere cloud field maxOnlineSlaves.