### PR TITLE
Implement JENKINS-22437

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereGuestInfoProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereGuestInfoProperty.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.vsphere;
+
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Represents a name/value pair that's sent to a vSphere virtual machine's
+ * "guestinfo" object.
+ */
+public final class VSphereGuestInfoProperty implements Describable<VSphereGuestInfoProperty> {
+    private final String name;
+    private final String value;
+
+    @DataBoundConstructor
+    public VSphereGuestInfoProperty(String name, String value) {
+        this.name = name == null ? "" : name.trim();
+        this.value = value;
+    }
+
+    public String getName() {
+        return name == null ? "" : name.trim();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public Descriptor<VSphereGuestInfoProperty> getDescriptor() {
+        return Jenkins.getInstance().getDescriptor(getClass());
+    }
+
+    @Extension
+    public static final class VSphereGuestInfoPropertyDescriptorImpl extends Descriptor<VSphereGuestInfoProperty> {
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/vSphereStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/vSphereStep.java
@@ -70,19 +70,15 @@ public class vSphereStep extends AbstractStepImpl {
 
         public ListBoxModel doFillServerNameItems() {
             ListBoxModel select = new ListBoxModel();
-
             try {
-                boolean hasVsphereClouds = false;
                 for (Cloud cloud : Hudson.getInstance().clouds) {
                     if (cloud instanceof vSphereCloud) {
-                        hasVsphereClouds = true;
                         select.add(((vSphereCloud) cloud).getVsDescription());
                     }
                 }
             } catch (Exception e) {
                 e.printStackTrace();
             }
-
             return select;
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -70,6 +70,15 @@
             <c:select/>
         </f:entry>
 
+        <f:entry title="${%GuestInfo Properties}" help="${descriptor.getHelpFile('guestInfoProperties')}">
+            <f:repeatable field="guestInfoProperties" add="${%Add}">
+                <st:include page="config.jelly" class="${descriptor.clazz}"/>
+                <div align="right">
+                    <f:repeatableDeleteButton value="${%Delete}"/>
+                </div>
+            </f:repeatable>
+        </f:entry>
+
         <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties"/>
     </table>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-guestInfoProperties.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-guestInfoProperties.html
@@ -1,0 +1,37 @@
+<div>
+Uses the vSphere "GuestInfo" data object to pass information to the newly-cloned virtual machine.
+The guest operating system can retrieve this information using the <tt>vmtoolsd</tt> utility.
+<br></br>
+e.g. Passing in a GuestInfo property named
+"<tt>JNLPURL</tt>"
+with value
+"<tt>${JENKINS_URL}computer/${NODE_NAME}/slave-agent.jnlp</tt>"
+could tell a virtual machine what URL to connect to in order to run the Jenkins slave.jar agent,
+and the virtual machine could retrieve that information using the command
+<tt>vmtoolsd --cmd "info-get guestinfo.JNLPURL"</tt>.
+<p>
+Variables which can be used within the values of these properties include
+<ul>
+<li>All variables from the Jenkins global configuration, e.g. environment variables.</li>
+<li>All variables exposed from "this" node's own properties, e.g. tool locations.</li>
+<li>Environment variables available in build steps that are not build-dependent:
+<tt>JENKINS_URL</tt>,
+<tt>NODE_NAME</tt>,
+<tt>NODE_LABELS</tt>.
+</li>
+<li>The following properties from this vSphere template definition:
+<tt>cluster</tt>,
+<tt>datastore</tt>,
+<tt>labelString</tt>,
+<tt>masterImageName</tt>,
+<tt>remoteFS</tt>,
+<tt>snapshotName</tt>,
+<tt>targetHost</tt>,
+<tt>templateDescription</tt>
+</li>
+</ul>
+</p>
+Note: This is not a list of properties that are exposed as GuestInfo properties by default.
+The above list is a list of variables that <em>may</em> be used in the GuestInfo properties.
+By default, no GuestInfo properties are passed.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereGuestInfoProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereGuestInfoProperty/config.jelly
@@ -1,0 +1,11 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <table width="100%">
+        <f:entry title="${%Property Name}" field="name">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry title="${%Property Value}" field="value">
+            <f:textbox/>
+        </f:entry>
+    </table>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -164,6 +164,6 @@ public class CloudProvisioningAlgorithmTest {
 
     private static vSphereCloudSlaveTemplate stubTemplate(String prefix, int templateInstanceCap) {
         return new vSphereCloudSlaveTemplate(prefix, "", null, false, null, null, null, null, templateInstanceCap, 1,
-                null, null, null, false, false, 0, 0, false, null, null, null, null);
+                null, null, null, false, false, 0, 0, false, null, null, null, null, null);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
@@ -263,7 +263,7 @@ public class CloudProvisioningStateTest {
         final vSphereCloudSlaveTemplate template = new vSphereCloudSlaveTemplate(cloneNamePrefix, "masterImageName",
                 "snapshotName", false, "cluster", "resourcePool", "datastore", "templateDescription", 0, 1, "remoteFS",
                 "", Mode.NORMAL, false, false, 0, 0, false, "targetResourcePool", "targetHost", "credentialsId",
-                Collections.EMPTY_LIST);
+                Collections.EMPTY_LIST, Collections.EMPTY_LIST);
         stubVSphereCloudTemplates.add(template);
         final List<vSphereCloudSlaveTemplate> templates = new ArrayList<vSphereCloudSlaveTemplate>();
         templates.add(template);


### PR DESCRIPTION
Adds new functionality the cloud slave templates - the ability to pass in data from Jenkins to the new VM's "guestinfo" object, which the guest OS can then read using VMware tools.
This provides a solution to https://issues.jenkins-ci.org/browse/JENKINS-22437 and perhaps https://issues.jenkins-ci.org/browse/JENKINS-20743 as well.