### PR TITLE
Bugfix jenkins 36878

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -381,9 +381,9 @@ public class vSphereCloud extends Cloud {
         try {
             vSphere = vSphereInstance();
             vSphere.destroyVm(cloneName, false);
-            VSLOG.log(Level.FINER, "provisionedSlaveHasTerminated({0}): VM deleted", cloneName);
+            VSLOG.log(Level.FINER, "provisionedSlaveHasTerminated({0}): VM destroyed.", cloneName);
         } catch (VSphereException ex) {
-            VSLOG.log(Level.SEVERE, "provisionedSlaveHasTerminated({0}): Exception while trying to destroy VM", ex);
+            VSLOG.log(Level.SEVERE, "provisionedSlaveHasTerminated(" + cloneName + "): Exception while trying to destroy VM", ex);
         } finally {
             if (vSphere != null) {
                 vSphere.disconnect();

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudProvisionedSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudProvisionedSlave.java
@@ -21,21 +21,17 @@ import org.kohsuke.stapler.QueryParameter;
 
 import com.vmware.vim25.mo.VirtualMachine;
 import com.vmware.vim25.mo.VirtualMachineSnapshot;
+
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.vsphere.tools.VSphere;
-import org.jenkinsci.plugins.vsphere.tools.VSphereException;
 
 /**
  *
  * @author Admin
  */
 public class vSphereCloudProvisionedSlave extends vSphereCloudSlave {
-    private static final Logger LOGGER = Logger.getLogger(vSphereCloudProvisionedSlave.class.getName());
-
     @DataBoundConstructor
     public vSphereCloudProvisionedSlave(String name, String nodeDescription,
             String remoteFS, String numExecutors, Mode mode,
@@ -62,24 +58,13 @@ public class vSphereCloudProvisionedSlave extends vSphereCloudSlave {
     protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
         super._terminate(listener);
         final vSphereCloudLauncher launcher = (vSphereCloudLauncher) getLauncher();
-        if(launcher != null) {
+        if (launcher != null) {
             final vSphereCloud cloud = launcher.findOurVsInstance();
-
-            if(cloud != null) {
-                VSphere vSphere = null;
-                try {
-                    vSphere = cloud.vSphereInstance();
-                    vSphere.destroyVm(this.getComputer().getName(), false);
-                } catch (VSphereException ex) {
-                    java.util.logging.Logger.getLogger(vSphereCloudProvisionedSlave.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
-                } finally {
-                    if(vSphere != null) {
-                        vSphere.disconnect();
-                    }
-                }
+            if (cloud != null) {
+                final String cloneName = this.getComputer().getName();
+                cloud.provisionedSlaveHasTerminated(cloneName);
             }
         }
-
     }
 
     @Extension

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -1,16 +1,14 @@
 package org.jenkinsci.plugins.vsphere.tools;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.hamcrest.core.IsSame;
 import org.jenkinsci.plugins.vSphereCloudSlaveTemplate;
-import org.jenkinsci.plugins.vsphere.tools.CloudProvisioningRecord;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +25,7 @@ public class CloudProvisioningAlgorithmTest {
     @Test
     public void findTemplateWithMostFreeCapacityGivenNoOptionsThenReturnsNull() {
         // Given
-        final List<CloudProvisioningRecord> emptyList = Collections.EMPTY_LIST;
+        final List<CloudProvisioningRecord> emptyList = Collections.emptyList();
 
         // When
         final CloudProvisioningRecord actual = CloudProvisioningAlgorithm.findTemplateWithMostFreeCapacity(emptyList);


### PR DESCRIPTION
Bugfix to code written for JENKINS-36878.
That code introduced an unwanted link from slaves to the cloud's transient state which then appeared in the serialised data.
Cloud Slaves now re-discover where they came from when they exit.