### PR TITLE
Re-fix JENKINS-24661

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
@@ -26,7 +26,6 @@ import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.RetentionStrategy;
-import hudson.util.FormValidation;
 import hudson.util.TimeUnit2;
 
 import java.io.IOException;
@@ -38,7 +37,6 @@ import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
 /**
  *

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
@@ -3,12 +3,10 @@ package org.jenkinsci.plugins.vsphere;
 import hudson.model.Descriptor;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
-import hudson.util.FormValidation;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
 public class VSphereCloudRetentionStrategy extends CloudRetentionStrategy {
 

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningRecord.java
@@ -1,10 +1,7 @@
 package org.jenkinsci.plugins.vsphere.tools;
 
-import java.util.Collection;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.jenkinsci.plugins.vSphereCloudSlaveTemplate;

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -8,13 +8,16 @@
             <f:textbox/>
         </f:entry>
 
-        <f:entry title="${%Snapshot Name}" field="snapshotName">
-            <f:textbox/>
-        </f:entry>
+        <f:optionalBlock title="${%Use Snapshot}" field="useSnapshot" inline="true">
+            <f:entry title="${%Snapshot Name}" field="snapshotName">
+                <f:textbox field="snapshotName"/>
+            </f:entry>
+        </f:optionalBlock>
 
         <f:entry title="${%Linked Clone}" field="linkedClone">
             <f:checkbox/>
         </f:entry>
+        <f:validateButton title="${%Check Template}" progress="${%Testing...}" method="testCloneParameters" with="vsHost,vsDescription,credentialsId,masterImageName,linkedClone,useSnapshot,snapshotName"/>
 
         <f:entry title="${%Cluster}" field="cluster">
             <f:textbox/>
@@ -37,7 +40,7 @@
         </f:entry>
 
         <f:entry title="${%# of Executors}" field="numberOfExecutors">
-            <f:textbox clazz="required number" default="1"/>
+            <f:textbox clazz="required positive-number" default="1"/>
         </f:entry>
 
         <f:entry title="${%Remote FS Root}" field="remoteFS">

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-linkedClone.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-linkedClone.html
@@ -1,0 +1,6 @@
+<div>
+  Linked clones will re-use any read-only disk backings (like snapshots) and create new children for your clone.
+  This requires that you have at least one snapshot in your master image.
+  <br/>
+  Enabling this will save (a lot of) time starting the clone, but the disk backings will be shared (reducing performance).
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-masterImageName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-masterImageName.html
@@ -1,3 +1,4 @@
 <div>
-Name of the virtual machine as it appears in vSphere.
+Name of the machine to be cloned, exactly as it appears in vSphere.<br/>
+This can either be the name of a Template or the name of a Virtual Machine.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-snapshotName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-snapshotName.html
@@ -1,3 +1,5 @@
 <div>
-OPTIONAL - the name of a snapshot of the virtual machine.
+The name of a snapshot in the master image that should be used as the basis for the clone.
+<br/>
+An empty string means "the current snapshot" for that VM.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-useSnapshot.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-useSnapshot.html
@@ -1,0 +1,6 @@
+<div>
+If set then the clone will be based upon one of the snapshots in the master image.
+You then have a choice of specifying a named snapshot, or leaving it empty to choose the "current" snapshot.
+<br/>
+This field should not be set if the master image has no snapshots.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -271,7 +271,7 @@ public class CloudProvisioningAlgorithmTest {
     }
 
     private static vSphereCloudSlaveTemplate stubTemplate(String prefix, int templateInstanceCap) {
-        return new vSphereCloudSlaveTemplate(prefix, "", null, false, null, null, null, null, templateInstanceCap, 1,
+        return new vSphereCloudSlaveTemplate(prefix, "", null, null, false, null, null, null, null, templateInstanceCap, 1,
                 null, null, null, false, false, 0, 0, false, null, null, null, new JNLPLauncher(),
                 RetentionStrategy.NOOP, null, null);
     }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
@@ -332,7 +332,7 @@ public class CloudProvisioningStateTest {
         recordNumber++;
         final String cloneNamePrefix = "prefix" + recordNumber;
         final vSphereCloudSlaveTemplate template = new vSphereCloudSlaveTemplate(cloneNamePrefix, "masterImageName",
-                "snapshotName", false, "cluster", "resourcePool", "datastore", "templateDescription", 0, 1, "remoteFS",
+                null, "snapshotName", false, "cluster", "resourcePool", "datastore", "templateDescription", 0, 1, "remoteFS",
                 "", Mode.NORMAL, false, false, 0, 0, false, "targetResourcePool", "targetHost", null,
                 new JNLPLauncher(), RetentionStrategy.NOOP, Collections.<NodeProperty<?>> emptyList(),
                 Collections.<VSphereGuestInfoProperty> emptyList());


### PR DESCRIPTION
We can now create a cloud-slave from a vSphere Template - we no longer require our cloud-slave's "master image" to be a VM that contains a snapshot.