### PR TITLE
Expose customization spec setting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -89,6 +89,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
     private final String cluster;
     private final String resourcePool;
     private final String datastore;
+    private final String customizationSpec;
     private final String templateDescription;
     private int templateInstanceCap;
     private final int numberOfExecutors;
@@ -125,6 +126,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                                      final String cluster,
                                      final String resourcePool,
                                      final String datastore,
+                                     final String customizationSpec,
                                      final String templateDescription,
                                      final int templateInstanceCap,
                                      final int numberOfExecutors,
@@ -151,6 +153,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         this.cluster = cluster;
         this.resourcePool = resourcePool;
         this.datastore = datastore;
+        this.customizationSpec = customizationSpec;
         this.templateDescription = templateDescription;
         this.templateInstanceCap = templateInstanceCap;
         this.numberOfExecutors = numberOfExecutors;
@@ -202,6 +205,10 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
 
     public String getDatastore() {
         return this.datastore;
+    }
+
+    public String getCustomizationSpec() {
+        return this.customizationSpec;
     }
 
     public String getTemplateDescription() {
@@ -357,7 +364,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             useCurrentSnapshot = false;
             snapshotToUse = null;
         }
-        vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, useCurrentSnapshot, snapshotToUse, POWER_ON, logger);
+        vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, useCurrentSnapshot, snapshotToUse, POWER_ON, this.customizationSpec, logger);
         try {
             if( this.guestInfoProperties!=null && !this.guestInfoProperties.isEmpty()) {
                 final Map<String, String> resolvedGuestInfoProperties = calculateGuestInfoProperties(cloneName, listener);
@@ -555,6 +562,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         addEnvVar(knownVariables, "NODE_LABELS", getLabelSet() == null ? null : Util.join(getLabelSet(), " "));
         addEnvVar(knownVariables, "cluster", this.cluster);
         addEnvVar(knownVariables, "datastore", this.datastore);
+        addEnvVar(knownVariables, "customizationSpec", this.customizationSpec);
         addEnvVar(knownVariables, "labelString", this.labelString);
         addEnvVar(knownVariables, "masterImageName", this.masterImageName);
         addEnvVar(knownVariables, "remoteFS", this.remoteFS);

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -49,18 +49,20 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 	private final String resourcePool;
 	private final String cluster;
     private final String datastore;
+    private final String customizationSpec;
     private final boolean powerOn;
 	private String IP;
 
 	@DataBoundConstructor
 	public Deploy(String template, String clone, boolean linkedClone,
-		      String resourcePool, String cluster, String datastore, boolean powerOn) throws VSphereException {
+		      String resourcePool, String cluster, String datastore, String customizationSpec, boolean powerOn) throws VSphereException {
 		this.template = template;
 		this.clone = clone;
 		this.linkedClone = linkedClone;
 		this.resourcePool= (resourcePool != null) ? resourcePool : "";
 		this.cluster=cluster;
         this.datastore=datastore;
+        this.customizationSpec=customizationSpec;
 		this.powerOn=powerOn;
 	}
 
@@ -86,6 +88,10 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 
     public String getDatastore() {
         return datastore;
+    }
+
+    public String getCustomizationSpec() {
+        return customizationSpec;
     }
 
     public boolean isPowerOn() {
@@ -144,6 +150,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 		String expandedTemplate = template;
 		String expandedCluster = cluster;
 		String expandedDatastore = datastore;
+                String expandedCustomizationSpec = customizationSpec;
 		EnvVars env;
 		try {
 			env = run.getEnvironment(listener);
@@ -157,6 +164,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 			expandedTemplate = env.expand(template);
 			expandedCluster = env.expand(cluster);
 			expandedDatastore = env.expand(datastore);
+                        expandedCustomizationSpec = env.expand(customizationSpec);
 		}
 
         String resourcePoolName;
@@ -168,7 +176,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             resourcePoolName = env.expand(resourcePool);
         }
 
-        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, powerOn, jLogger);
+        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, powerOn, expandedCustomizationSpec, jLogger);
 		VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
 		if (!powerOn) {
 			return true; // don't try to obtain IP if VM isn't being turned on.

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -31,6 +31,10 @@
             <f:textbox/>
         </f:entry>
 
+        <f:entry title="${%Customization Specification}" field="customizationSpec">
+            <f:textbox/>
+        </f:entry>
+
         <f:entry title="${%Description}" field="templateDescription">
             <f:textbox/>
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-customizationSpec.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-customizationSpec.html
@@ -1,0 +1,3 @@
+<div>
+    Name of a customization specification to use when cloning this machine.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -271,7 +271,7 @@ public class CloudProvisioningAlgorithmTest {
     }
 
     private static vSphereCloudSlaveTemplate stubTemplate(String prefix, int templateInstanceCap) {
-        return new vSphereCloudSlaveTemplate(prefix, "", null, null, false, null, null, null, null, templateInstanceCap, 1,
+        return new vSphereCloudSlaveTemplate(prefix, "", null, null, false, null, null, null, null, null, templateInstanceCap, 1,
                 null, null, null, false, false, 0, 0, false, null, null, null, new JNLPLauncher(),
                 RetentionStrategy.NOOP, null, null);
     }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
@@ -332,7 +332,7 @@ public class CloudProvisioningStateTest {
         recordNumber++;
         final String cloneNamePrefix = "prefix" + recordNumber;
         final vSphereCloudSlaveTemplate template = new vSphereCloudSlaveTemplate(cloneNamePrefix, "masterImageName",
-                null, "snapshotName", false, "cluster", "resourcePool", "datastore", "templateDescription", 0, 1, "remoteFS",
+                null, "snapshotName", false, "cluster", "resourcePool", "datastore", "customizationSpec", "templateDescription", 0, 1, "remoteFS",
                 "", Mode.NORMAL, false, false, 0, 0, false, "targetResourcePool", "targetHost", null,
                 new JNLPLauncher(), RetentionStrategy.NOOP, Collections.<NodeProperty<?>> emptyList(),
                 Collections.<VSphereGuestInfoProperty> emptyList());


### PR DESCRIPTION
When cloning VMs, we often want to apply Guest OS customization through
the use of customization specifications. These might change hostname,
join domains and other things. This simply exposes a setting for the
cloud slave template to control what customization specification to use,
or none if left blank.

See https://issues.jenkins-ci.org/browse/JENKINS-39261