### PR TITLE
VSphere folder parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -89,6 +89,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
     private final String cluster;
     private final String resourcePool;
     private final String datastore;
+    private final String folder;
     private final String customizationSpec;
     private final String templateDescription;
     private int templateInstanceCap;
@@ -126,6 +127,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                                      final String cluster,
                                      final String resourcePool,
                                      final String datastore,
+                                     final String folder,
                                      final String customizationSpec,
                                      final String templateDescription,
                                      final int templateInstanceCap,
@@ -153,6 +155,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         this.cluster = cluster;
         this.resourcePool = resourcePool;
         this.datastore = datastore;
+        this.folder = folder;
         this.customizationSpec = customizationSpec;
         this.templateDescription = templateDescription;
         this.templateInstanceCap = templateInstanceCap;
@@ -205,6 +208,10 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
 
     public String getDatastore() {
         return this.datastore;
+    }
+    
+    public String getFolder() {
+        return this.folder;
     }
 
     public String getCustomizationSpec() {
@@ -364,7 +371,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             useCurrentSnapshot = false;
             snapshotToUse = null;
         }
-        vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, useCurrentSnapshot, snapshotToUse, POWER_ON, this.customizationSpec, logger);
+        vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, this.folder, useCurrentSnapshot, snapshotToUse, POWER_ON, this.customizationSpec, logger);
         try {
             if( this.guestInfoProperties!=null && !this.guestInfoProperties.isEmpty()) {
                 final Map<String, String> resolvedGuestInfoProperties = calculateGuestInfoProperties(cloneName, listener);
@@ -562,6 +569,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         addEnvVar(knownVariables, "NODE_LABELS", getLabelSet() == null ? null : Util.join(getLabelSet(), " "));
         addEnvVar(knownVariables, "cluster", this.cluster);
         addEnvVar(knownVariables, "datastore", this.datastore);
+        addEnvVar(knownVariables, "folder", this.folder);
         addEnvVar(knownVariables, "customizationSpec", this.customizationSpec);
         addEnvVar(knownVariables, "labelString", this.labelString);
         addEnvVar(knownVariables, "masterImageName", this.masterImageName);

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -45,20 +45,22 @@ public class Clone extends VSphereBuildStep {
     private final String resourcePool;
     private final String cluster;
     private final String datastore;
+    private final String folder;
     private final String customizationSpec;
     private final boolean powerOn;
     private String IP;
 
     @DataBoundConstructor
     public Clone(String sourceName, String clone, boolean linkedClone,
-                 String resourcePool, String cluster, String datastore, boolean powerOn,
-		 String customizationSpec) throws VSphereException {
+                 String resourcePool, String cluster, String datastore, String folder,
+                 boolean powerOn, String customizationSpec) throws VSphereException {
         this.sourceName = sourceName;
         this.clone = clone;
         this.linkedClone = linkedClone;
         this.resourcePool=resourcePool;
         this.cluster=cluster;
         this.datastore=datastore;
+        this.folder=folder;
 	this.customizationSpec=customizationSpec;
         this.powerOn=powerOn;
     }
@@ -85,6 +87,10 @@ public class Clone extends VSphereBuildStep {
 
     public String getDatastore() {
         return datastore;
+    }
+    
+    public String getFolder() {
+        return folder;
     }
 
     public String getCustomizationSpec() {
@@ -127,6 +133,7 @@ public class Clone extends VSphereBuildStep {
         String expandedSource = sourceName;
         String expandedCluster = cluster;
         String expandedDatastore = datastore;
+        String expandedFolder = folder;
         String expandedResourcePool = resourcePool;
         String expandedCustomizationSpec = customizationSpec;
         EnvVars env;
@@ -142,11 +149,12 @@ public class Clone extends VSphereBuildStep {
             expandedSource = env.expand(sourceName);
             expandedCluster = env.expand(cluster);
             expandedDatastore = env.expand(datastore);
+            expandedFolder = env.expand(folder);
             expandedResourcePool = env.expand(resourcePool);
             expandedCustomizationSpec = env.expand(customizationSpec);
         }
         vsphere.cloneVm(expandedClone, expandedSource, linkedClone, expandedResourcePool, expandedCluster,
-                expandedDatastore, powerOn, expandedCustomizationSpec, jLogger);
+                expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, jLogger);
         if (powerOn) {
             IP = vsphere.getIp(vsphere.getVmByName(expandedClone), 60);
         }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -49,19 +49,21 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 	private final String resourcePool;
 	private final String cluster;
     private final String datastore;
+    private final String folder;
     private final String customizationSpec;
     private final boolean powerOn;
 	private String IP;
 
 	@DataBoundConstructor
 	public Deploy(String template, String clone, boolean linkedClone,
-		      String resourcePool, String cluster, String datastore, String customizationSpec, boolean powerOn) throws VSphereException {
+		      String resourcePool, String cluster, String datastore, String folder, String customizationSpec, boolean powerOn) throws VSphereException {
 		this.template = template;
 		this.clone = clone;
 		this.linkedClone = linkedClone;
 		this.resourcePool= (resourcePool != null) ? resourcePool : "";
 		this.cluster=cluster;
         this.datastore=datastore;
+        this.folder=folder;
         this.customizationSpec=customizationSpec;
 		this.powerOn=powerOn;
 	}
@@ -88,6 +90,10 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 
     public String getDatastore() {
         return datastore;
+    }
+    
+    public String getFolder() {
+        return folder;
     }
 
     public String getCustomizationSpec() {
@@ -150,6 +156,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 		String expandedTemplate = template;
 		String expandedCluster = cluster;
 		String expandedDatastore = datastore;
+                String expandedFolder = folder;
                 String expandedCustomizationSpec = customizationSpec;
 		EnvVars env;
 		try {
@@ -164,6 +171,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 			expandedTemplate = env.expand(template);
 			expandedCluster = env.expand(cluster);
 			expandedDatastore = env.expand(datastore);
+                        expandedFolder = env.expand(folder);
                         expandedCustomizationSpec = env.expand(customizationSpec);
 		}
 
@@ -176,7 +184,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             resourcePoolName = env.expand(resourcePool);
         }
 
-        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, powerOn, expandedCustomizationSpec, jLogger);
+        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, jLogger);
 		VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
 		if (!powerOn) {
 			return true; // don't try to obtain IP if VM isn't being turned on.

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -30,6 +30,10 @@
         <f:entry title="${%Datastore}" field="datastore">
             <f:textbox/>
         </f:entry>
+        
+        <f:entry title="${%Folder}" field="folder">
+            <f:textbox/>
+        </f:entry>
 
         <f:entry title="${%Customization Specification}" field="customizationSpec">
             <f:textbox/>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-folder.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-folder.html
@@ -1,0 +1,7 @@
+<div>
+    (Optional) VSphere folder path or unique folder name where VM is going to be created.
+    <br>
+    If blank, it will be created in the same folder as the original VM.
+    <br>
+</div>
+

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
@@ -38,6 +38,10 @@ limitations under the License.
   <f:entry title="${%Datastore}" field="datastore">
     <f:textbox  />
   </f:entry>
+  
+  <f:entry title="${%Folder}" field="datastore">
+    <f:textbox  />
+  </f:entry>
 
   <f:entry title="${%Power on?}" field="powerOn">
     <f:checkbox  />

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-folder.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-folder.html
@@ -1,0 +1,7 @@
+<div>
+    (Optional) VSphere folder path or unique folder name where VM is going to be created.
+    <br>
+    If blank, it will be created in the same folder as the original VM.
+    <br>
+</div>
+

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
@@ -39,6 +39,10 @@ limitations under the License.
     <f:textbox  />
   </f:entry>
 
+  <f:entry title="${%Folder}" field="Folder">
+    <f:textbox  />
+  </f:entry>
+
   <f:entry title="${%Power on?}" field="powerOn">
     <f:checkbox  />
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-folder.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-folder.html
@@ -1,0 +1,7 @@
+<div>
+    (Optional) VSphere folder path or unique folder name where VM is going to be created.
+    <br>
+    If blank, it will be created in the same folder as the original VM.
+    <br>
+</div>
+

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -271,7 +271,7 @@ public class CloudProvisioningAlgorithmTest {
     }
 
     private static vSphereCloudSlaveTemplate stubTemplate(String prefix, int templateInstanceCap) {
-        return new vSphereCloudSlaveTemplate(prefix, "", null, null, false, null, null, null, null, null, templateInstanceCap, 1,
+        return new vSphereCloudSlaveTemplate(prefix, "", null, null, false, null, null, null, null, null, null, templateInstanceCap, 1,
                 null, null, null, false, false, 0, 0, false, null, null, null, new JNLPLauncher(),
                 RetentionStrategy.NOOP, null, null);
     }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
@@ -332,7 +332,7 @@ public class CloudProvisioningStateTest {
         recordNumber++;
         final String cloneNamePrefix = "prefix" + recordNumber;
         final vSphereCloudSlaveTemplate template = new vSphereCloudSlaveTemplate(cloneNamePrefix, "masterImageName",
-                null, "snapshotName", false, "cluster", "resourcePool", "datastore", "customizationSpec", "templateDescription", 0, 1, "remoteFS",
+                null, "snapshotName", false, "cluster", "resourcePool", "datastore", "folder", "customizationSpec", "templateDescription", 0, 1, "remoteFS",
                 "", Mode.NORMAL, false, false, 0, 0, false, "targetResourcePool", "targetHost", null,
                 new JNLPLauncher(), RetentionStrategy.NOOP, Collections.<NodeProperty<?>> emptyList(),
                 Collections.<VSphereGuestInfoProperty> emptyList());


### PR DESCRIPTION
A new folder parameter has been added for templates and clone/deploy
actions.

This parameter creates the new VM in the specified folder of vSphere
(which can be a path of folders or a unique name folder).

If left blank or folder not available, it will create the VM in the same
folder as the original VM.

It is specially interesting for organizing and separating templates from
autodeployed slaves.
For example, we have daily backups and we want separate folders for
templates and autodeployed dynamic slaves, so we can specify to backup
only the folders that contain the templates and omit folders that
contain the dynamic slaves.