### PR TITLE
Adding Datadog StatsD support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
             <type>jar</type>
         </dependency>
         <dependency>
+            <groupId>com.datadoghq</groupId>
+            <artifactId>java-dogstatsd-client</artifactId>
+            <version>2.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <version>1.28</version>

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -7,6 +7,8 @@ package org.jenkinsci.plugins;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.Descriptor.FormException;
@@ -31,15 +33,16 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.ArrayList; 
+import java.util.Collection; 
+import java.util.Collections; 
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author Admin
@@ -54,6 +57,10 @@ public class vSphereCloud extends Cloud {
     @Deprecated
     private transient String password;
     private final int maxOnlineSlaves;
+    private final boolean useDDStatsd;
+    private final String statsdHost;
+    private final int statsdPort;
+    
     private
     @CheckForNull
     VSphereConnectionConfig vsConnectionConfig;
@@ -66,7 +73,8 @@ public class vSphereCloud extends Cloud {
     private transient CloudProvisioningState templateState;
 
     private static java.util.logging.Logger VSLOG = java.util.logging.Logger.getLogger("vsphere-cloud");
-
+    private StatsDClient statsdClient;
+    
     private static void InternalLog(Slave slave, SlaveComputer slaveComputer, TaskListener listener, Throwable ex, String format, Object... args) {
         final Level logLevel = Level.INFO;
         if (!VSLOG.isLoggable(logLevel) && listener == null)
@@ -90,7 +98,7 @@ public class vSphereCloud extends Cloud {
             VSLOG.log(logLevel, s);
         }
     }
-
+    
     public static void Log(String format, Object... args) {
         InternalLog(null, null, null, null, format, args);
     }
@@ -129,24 +137,43 @@ public class vSphereCloud extends Cloud {
 
     public static void Log(SlaveComputer slave, TaskListener listener, Throwable ex, String format, Object... args) {
         InternalLog(null, slave, listener, ex, format, args);
-    }
-
+    }  
+    
     @Deprecated
     public vSphereCloud(String vsHost, String vsDescription,
-                        String username, String password, int maxOnlineSlaves) {
-        this(null, vsDescription, maxOnlineSlaves, 0, null);
+                        String username, String password, int maxOnlineSlaves, String statsdHost, int statsdPort, boolean useDDStatsd) {
+        this(null, vsDescription, maxOnlineSlaves, 0, null, statsdHost, statsdPort, useDDStatsd);
     }
 
     @DataBoundConstructor
-    public vSphereCloud(VSphereConnectionConfig vsConnectionConfig, String vsDescription, int maxOnlineSlaves, int instanceCap, List<? extends vSphereCloudSlaveTemplate> templates) {
+    public vSphereCloud(VSphereConnectionConfig vsConnectionConfig, String vsDescription, int maxOnlineSlaves, int instanceCap, List<? extends vSphereCloudSlaveTemplate> templates, String statsdHost, int statsdPort, boolean useDDStatsd) {
         super("vSphereCloud");
         this.vsDescription = vsDescription;
         this.maxOnlineSlaves = maxOnlineSlaves;
         this.vsConnectionConfig = vsConnectionConfig;
+        this.statsdHost = statsdHost;
+        this.statsdPort = statsdPort;
+        this.useDDStatsd = useDDStatsd;
+        
+        if(this.useDDStatsd && statsdClient == null) {
+            try{
+                statsdClient = new NonBlockingStatsDClient(
+                            "vsphere-cloud",            /* prefix to any stats; may be null or empty string */
+                            this.statsdHost,                 /* common case: localhost */
+                            this.statsdPort,                 /* port */
+                            new String[] {""}           /* Datadog extension: Constant tags, always applied */
+                );
+                Log("Success in connecting to statsd host["+statsdHost+"] on port["+statsdPort+"].");
+            } catch(Exception e) {
+                Log("Failed to connect to statsd host["+statsdHost+"] on port["+statsdPort+"].");
+                Log(e.toString());
+            }
+        }
+        
         if (templates == null) {
             this.templates = Collections.emptyList();
         } else {
-            this.templates = templates;
+            this.templates = templates; 
         }
 
         if (instanceCap == 0) {
@@ -237,7 +264,7 @@ public class vSphereCloud extends Cloud {
         }
         return matchingTemplates;
     }
-
+    
     public
     @CheckForNull
     String getPassword() {
@@ -254,6 +281,21 @@ public class vSphereCloud extends Cloud {
         return vsDescription;
     }
 
+    public 
+    String getStatsdHost() {
+        return statsdHost;
+    }
+    
+    public 
+    int getStatsdPort() {
+        return statsdPort;
+    }
+    
+    public 
+    boolean getUseDDStatsd() {
+        return useDDStatsd;
+    }
+    
     public
     @CheckForNull
     String getVsHost() {
@@ -337,13 +379,16 @@ public class vSphereCloud extends Cloud {
             synchronized (templateState) {
                 templateState.pruneUnwantedRecords();
                 Integer maxSlavesToProvisionBeforeCloudCapHit = calculateMaxAdditionalSlavesPermitted();
+
                 if (maxSlavesToProvisionBeforeCloudCapHit != null && maxSlavesToProvisionBeforeCloudCapHit <= 0) {
                     return Collections.emptySet(); // no capacity due to cloud instance cap
                 }
+
                 final List<vSphereCloudSlaveTemplate> templates = getTemplates(label);
                 final List<CloudProvisioningRecord> whatWeCouldUse = templateState.calculateProvisionableTemplates(templates);
                 VSLOG.log(Level.INFO, methodCallDescription + ": " + numberOfvSphereCloudSlaves + " existing slaves (="
                         + numberOfvSphereCloudSlaveExecutors + " executors), templates available are " + whatWeCouldUse);
+
                 while (excessWorkloadSoFar > 0) {
                     if (maxSlavesToProvisionBeforeCloudCapHit != null) {
                         final int intValue = maxSlavesToProvisionBeforeCloudCapHit.intValue();
@@ -357,7 +402,7 @@ public class vSphereCloud extends Cloud {
                         break; // out of capacity due to template instance cap
                     }
                     final String nodeName = CloudProvisioningAlgorithm.findUnusedName(whatWeShouldSpinUp);
-                    final PlannedNode plannedNode = VSpherePlannedNode.createInstance(templateState, nodeName, whatWeShouldSpinUp);
+                    final PlannedNode plannedNode = VSpherePlannedNode.createInstance(templateState, nodeName, whatWeShouldSpinUp, useDDStatsd, statsdClient);
                     plannedNodes.add(plannedNode);
                     excessWorkloadSoFar -= plannedNode.numExecutors;
                 }
@@ -409,20 +454,25 @@ public class vSphereCloud extends Cloud {
 
         public static VSpherePlannedNode createInstance(final CloudProvisioningState templateState,
                                                         final String nodeName,
-                                                        final CloudProvisioningRecord whatWeShouldSpinUp) {
+                                                        final CloudProvisioningRecord whatWeShouldSpinUp,
+                                                        final boolean useDDStatsd,
+                                                        final StatsDClient statsdClient) {
             final vSphereCloudSlaveTemplate template = whatWeShouldSpinUp.getTemplate();
             final int numberOfExecutors = template.getNumberOfExecutors();
+
             final Callable<Node> provisionNodeCallable = new Callable<Node>() {
                 public Node call() throws Exception {
                     try {
                         final Node newNode = provisionNewNode(templateState, whatWeShouldSpinUp, nodeName);
                         VSLOG.log(Level.INFO, "Provisioned new slave " + nodeName);
+                        if(statsdClient != null && useDDStatsd) statsdClient.incrementCounter("provision.success."+whatWeShouldSpinUp.getTemplate().getMasterImageName());
                         synchronized (templateState) {
                             templateState.provisionedSlaveNowActive(whatWeShouldSpinUp, nodeName);
                         }
                         return newNode;
                     } catch (Exception ex) {
                         VSLOG.log(Level.WARNING, "Failed to provision new slave " + nodeName, ex);
+                        if(statsdClient != null && useDDStatsd) statsdClient.incrementCounter("provision.failed."+whatWeShouldSpinUp.getTemplate().getMasterImageName());
                         synchronized (templateState) {
                             templateState.provisioningEndedInError(whatWeShouldSpinUp, nodeName);
                         }
@@ -430,6 +480,7 @@ public class vSphereCloud extends Cloud {
                     }
                 }
             };
+
             templateState.provisioningStarted(whatWeShouldSpinUp, nodeName);
             final Future<Node> provisionNodeTask = Computer.threadPoolForRemoting.submit(provisionNodeCallable);
             final VSpherePlannedNode result = new VSpherePlannedNode(nodeName, provisionNodeTask, numberOfExecutors);
@@ -587,6 +638,10 @@ public class vSphereCloud extends Cloud {
         @Deprecated
         int maxOnlineSlaves;
 
+        private String statsdHost;
+        private int statsdPort;
+        private boolean useDDStatsd;
+
         @Override
         public String getDisplayName() {
             return "vSphere Cloud";
@@ -599,6 +654,10 @@ public class vSphereCloud extends Cloud {
             username = o.getString("username");
             password = o.getString("password");
             maxOnlineSlaves = o.getInt("maxOnlineSlaves");
+            statsdHost = o.getString("statsdHost");
+            statsdPort = o.getInt("statsdPort");
+            useDDStatsd = o.getBoolean("useDDStatsd");
+
             save();
             return super.configure(req, o);
         }

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
@@ -6,6 +6,15 @@
         <f:property field="vsConnectionConfig"/>
     </f:entry>
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="vsHost,vsDescription,credentialsId"/>
+   
+    <f:optionalBlock title="${%Use StatsD}" field="useDDStatsd" inline="true">
+        <f:entry title="${%StatsD Host}" field="statsdHost">
+            <f:textbox clazz="required"/>
+        </f:entry>
+        <f:entry title="${%StatsD Port}" field="statsdPort">
+            <f:textbox clazz="required number"/>
+        </f:entry>
+    </f:optionalBlock>
 
     <f:advanced>
         <f:entry title="${%Max number of VMs online}" field="maxOnlineSlaves" description="0 means unlimited.">

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-statsdHost.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-statsdHost.html
@@ -1,0 +1,4 @@
+<div>
+    The statsd host that will be used when forwarding telemetry.
+</div>
+<a href="help-statsdPort.html"></a>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-statsdPort.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-statsdPort.html
@@ -1,0 +1,3 @@
+<div>
+    The port which the statsd host is listening on.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useDDStatsd.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useDDStatsd.html
@@ -1,0 +1,3 @@
+<div>
+   Allows you to enable DataDog statsD integration. This will automatically log each provision attempt, and record those that pass, and those which fail to provision.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
@@ -45,7 +45,7 @@ public class CloudProvisioningStateTest {
     public static void setupClass() {
         stubVSphereCloudTemplates = new ArrayList<vSphereCloudSlaveTemplate>();
         final VSphereConnectionConfig vsConnectionConfig = new VSphereConnectionConfig("vsHost", "credentialsId");
-        stubVSphereCloud = new vSphereCloud(vsConnectionConfig, "vsDescription", 0, 0, stubVSphereCloudTemplates);
+        stubVSphereCloud = new vSphereCloud(vsConnectionConfig, "vsDescription", 0, 0, stubVSphereCloudTemplates, "test", 1, false);
     }
 
     @Before


### PR DESCRIPTION
Added datadog statsd support for the vSphere plugin in order to provide a deeper understanding of when automatically provisioned VMs succeed, and fail.

Currently supports two main metrics which follow the canonical logging namespace noticed in the original source:
- vsphere-cloud.provision.failed
- vsphere-cloud.provision.success

New dependency added on java-dogstatsd-client https://github.com/datadog/java-dogstatsd-client