### PR TITLE
Fixed issue when cloning and now properly handling general  exception

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -168,9 +168,10 @@ public class Clone extends VSphereBuildStep {
         vsphere.cloneVm(expandedClone, expandedSource, linkedClone, expandedResourcePool, expandedCluster,
                 expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, jLogger);
         if (powerOn) {
+            VSphereLogger.vsLogger(jLogger,"Powering on VM...");
             IP = vsphere.getIp(vsphere.getVmByName(expandedClone), 60);
         }
-        VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully cloned!");
+        VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully cloned " + (powerOn ? "and powered on" : "") + "!");
 
         return true;
     }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -61,7 +61,7 @@ public class Clone extends VSphereBuildStep {
         this.cluster=cluster;
         this.datastore=datastore;
         this.folder=folder;
-	this.customizationSpec=customizationSpec;
+        this.customizationSpec=customizationSpec;
         this.powerOn=powerOn;
     }
 
@@ -251,7 +251,7 @@ public class Clone extends VSphereBuildStep {
                 if (snap == null)
                     return FormValidation.error(Messages.validation_noSnapshots());
 
-                if(customizationSpec.length() > 0 &&
+                if(customizationSpec != null && customizationSpec.length() > 0 &&
                         vsphere.getCustomizationSpecByName(customizationSpec) == null) {
                     return FormValidation.error(Messages.validation_notFound("customizationSpec"));
                 }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -23,6 +23,9 @@ import hudson.util.FormValidation;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
@@ -116,15 +119,24 @@ public class Clone extends VSphereBuildStep {
     }
 
     @Override
-    public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)  {
+    public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws AbortException {
         boolean retVal = false;
         try {
             retVal = cloneFromSource(build, launcher, listener);
         } catch (Exception e) {
-            e.printStackTrace();
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            VSphereLogger.vsLogger(listener.getLogger(), "Error cloning VM or template\n" + sw.toString());
+
+            try {
+                sw.close();
+            } catch (Exception ex) {
+                // ignore
+            }
+            throw new AbortException(e.getMessage());
         }
         return retVal;
-        //TODO throw AbortException instead of returning value
     }
 
     private boolean cloneFromSource(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws VSphereException {

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
@@ -39,7 +39,7 @@ limitations under the License.
     <f:textbox  />
   </f:entry>
   
-  <f:entry title="${%Folder}" field="datastore">
+  <f:entry title="${%Folder}" field="folder">
     <f:textbox  />
   </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
@@ -47,5 +47,9 @@ limitations under the License.
     <f:checkbox  />
   </f:entry>
 
+  <f:entry title="${%Customization Specification}" field="customizationSpec">
+    <f:textbox/>
+  </f:entry>
+
   <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,sourceName,clone,resourcePool,cluster"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-customizationSpec.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-customizationSpec.html
@@ -1,0 +1,3 @@
+<div>
+  The customization specification name, as defined under 'Policies and Profiles'
+</div>


### PR DESCRIPTION
Fixed issue when cloning VM or template, introduced in previous commit that started using customization.
Jenkins build will now fail when an error occurs with the plugin.