### PR TITLE
Correct field names in the Jelly code for Folder parameter.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
@@ -39,7 +39,7 @@ limitations under the License.
     <f:textbox  />
   </f:entry>
   
-  <f:entry title="${%Folder}" field="datastore">
+  <f:entry title="${%Folder}" field="folder">
     <f:textbox  />
   </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
@@ -39,7 +39,7 @@ limitations under the License.
     <f:textbox  />
   </f:entry>
 
-  <f:entry title="${%Folder}" field="Folder">
+  <f:entry title="${%Folder}" field="folder">
     <f:textbox  />
   </f:entry>
 


### PR DESCRIPTION
Affects Clone and Deploy build steps.

This addresses the concerns raised in https://github.com/jenkinsci/vsphere-cloud-plugin/pull/61#issuecomment-307080040