### PR TITLE
Logging improvments.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -67,8 +67,7 @@ public class vSphereCloud extends Cloud {
 
     private static java.util.logging.Logger VSLOG = java.util.logging.Logger.getLogger("vsphere-cloud");
 
-    private static void InternalLog(Slave slave, SlaveComputer slaveComputer, TaskListener listener, Throwable ex, String format, Object... args) {
-        final Level logLevel = Level.INFO;
+    private static void InternalLog(Slave slave, SlaveComputer slaveComputer, TaskListener listener, Throwable ex, Level logLevel, String format, Object... args) {
         if (!VSLOG.isLoggable(logLevel) && listener == null)
             return;
         String s = "";
@@ -91,44 +90,54 @@ public class vSphereCloud extends Cloud {
         }
     }
 
+    /** Logs an {@link Level#INFO} message (created with {@link String#format(String, Object...)}). */
     public static void Log(String format, Object... args) {
-        InternalLog(null, null, null, null, format, args);
+        InternalLog(null, null, null, null, Level.INFO, format, args);
     }
 
+    /** Logs an {@link Level#SEVERE} message (created with {@link String#format(String, Object...)}) and a {@link Throwable} with stacktrace. */
     public static void Log(Throwable ex, String format, Object... args) {
-        InternalLog(null, null, null, ex, format, args);
+        InternalLog(null, null, null, ex, Level.SEVERE, format, args);
     }
 
+    /** Logs a {@link Level#INFO} message (created with {@link String#format(String, Object...)}). */
     public static void Log(TaskListener listener, String format, Object... args) {
-        InternalLog(null, null, listener, null, format, args);
+        InternalLog(null, null, listener, null, Level.INFO, format, args);
     }
 
+    /** Logs a {@link Level#SEVERE} message (created with {@link String#format(String, Object...)}) and a {@link Throwable} (with stacktrace). */
     public static void Log(TaskListener listener, Throwable ex, String format, Object... args) {
-        InternalLog(null, null, listener, ex, format, args);
+        InternalLog(null, null, listener, ex, Level.SEVERE, format, args);
     }
 
+    /** Logs a {@link Level#INFO} message (created with {@link String#format(String, Object...)}), prefixed by the {@link Slave} name. */
     public static void Log(Slave slave, String format, Object... args) {
-        InternalLog(slave, null, null, null, format, args);
+        InternalLog(slave, null, null, null, Level.INFO, format, args);
     }
 
+    /** Logs a {@link Level#SEVERE} message (created with {@link String#format(String, Object...)}) and a {@link Throwable} (with stacktrace), prefixed by the {@link Slave} name. */
     public static void Log(Slave slave, Throwable ex, String format, Object... args) {
-        InternalLog(slave, null, null, ex, format, args);
+        InternalLog(slave, null, null, ex, Level.SEVERE, format, args);
     }
 
+    /** Logs a {@link Level#INFO} message (created with {@link String#format(String, Object...)}), prefixed by the {@link Slave} name. */
     public static void Log(Slave slave, TaskListener listener, String format, Object... args) {
-        InternalLog(slave, null, listener, null, format, args);
+        InternalLog(slave, null, listener, null, Level.INFO, format, args);
     }
 
+    /** Logs a {@link Level#SEVERE} message (created with {@link String#format(String, Object...)}) and a {@link Throwable} (with stacktrace), prefixed by the {@link Slave} name. */
     public static void Log(Slave slave, TaskListener listener, Throwable ex, String format, Object... args) {
-        InternalLog(slave, null, listener, ex, format, args);
+        InternalLog(slave, null, listener, ex, Level.SEVERE, format, args);
     }
 
+    /** Logs a {@link Level#INFO} message (created with {@link String#format(String, Object...)}), prefixed by the {@link SlaveComputer} name. */
     public static void Log(SlaveComputer slave, TaskListener listener, String format, Object... args) {
-        InternalLog(null, slave, listener, null, format, args);
+        InternalLog(null, slave, listener, null, Level.INFO, format, args);
     }
 
+    /** Logs a {@link Level#SEVERE} message (created with {@link String#format(String, Object...)}) and a {@link Throwable} (with stacktrace), prefixed by the {@link SlaveComputer} name. */
     public static void Log(SlaveComputer slave, TaskListener listener, Throwable ex, String format, Object... args) {
-        InternalLog(null, slave, listener, ex, format, args);
+        InternalLog(null, slave, listener, ex, Level.SEVERE, format, args);
     }
 
     @Deprecated

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -111,6 +111,15 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
         return this;
     }
 
+    /**
+     * Find the {@link vSphereCloud} for this {@link vSphereCloudLauncher}, or
+     * dies trying.
+     * 
+     * @return The {@link vSphereCloud}. It will not return null.
+     * @throws RuntimeException
+     *             if it cannot find the {@link vSphereCloud} - e.g. if it's
+     *             been deleted or the description has changed.
+     */
     public vSphereCloud findOurVsInstance() throws RuntimeException {
         if (vsDescription != null && vmName != null) {
             for (vSphereCloud cloud : vSphereCloud.findAllVsphereClouds(null)) {

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudProvisionedSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudProvisionedSlave.java
@@ -57,13 +57,20 @@ public class vSphereCloudProvisionedSlave extends vSphereCloudSlave {
     @Override
     protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
         super._terminate(listener);
-        final vSphereCloudLauncher launcher = (vSphereCloudLauncher) getLauncher();
-        if (launcher != null) {
-            final vSphereCloud cloud = launcher.findOurVsInstance();
-            if (cloud != null) {
+        try {
+            final ComputerLauncher l = getLauncher();
+            final vSphereCloudLauncher launcher = l instanceof vSphereCloudLauncher ? (vSphereCloudLauncher) l : null;
+            if (launcher != null) {
+                final vSphereCloud cloud = launcher.findOurVsInstance();
                 final String cloneName = this.getComputer().getName();
                 cloud.provisionedSlaveHasTerminated(cloneName);
+            } else {
+                vSphereCloud.Log(listener, "%1s._terminate for vmName %2s failed as getLauncher() returned %3s",
+                        getClass().getSimpleName(), getVmName(), l);
             }
+        } catch (RuntimeException ex) {
+            vSphereCloud.Log(listener, ex, "%1s._terminate for vmName %2s failed",
+                    getClass().getSimpleName(), getVmName());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
@@ -142,10 +142,12 @@ public class vSphereCloudSlave extends AbstractCloudSlave {
                         return "Shutting down VSphere Cloud Slave";
                     }
                 });
-                vSphereCloud.Log(this, listener, "Disconnected computer");
+                vSphereCloud.Log(this, listener, "Disconnected computer %s", vmName);
+            } else {
+                vSphereCloud.Log(this, listener, "Can't disconnect computer for %s as there was no Computer node for it.", vmName);
             }
         } catch(Exception e) {
-            vSphereCloud.Log(this, listener, e, "Can't disconnect");
+            vSphereCloud.Log(this, listener, e, "Can't disconnect %s", vmName);
         }
     }
 


### PR DESCRIPTION
vSphereCloud's Log methods now log exceptions with Level.SEVERE instead of Level.INFO.  Non-exception logging is still Level.INFO.
vSphereCloudProvisionedSlave and vSphereCloudSlave's _terminate methods had some code paths that could fail silently - they now log something.