### PR TITLE
[JENKINS-44796] vSphereCloudLauncher enhancement

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -293,16 +293,21 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
         try {
             vSphereCloud.Log(slaveComputer, taskListener, "Running disconnect procedure...");
             super.afterDisconnect(slaveComputer, taskListener);
-            vSphereCloud.Log(slaveComputer, taskListener, "Shutting down Virtual Machine...");
             MACHINE_ACTION localIdle = idleAction;
             if (localIdle == null) {
                 localIdle = MACHINE_ACTION.SHUTDOWN;
             }
-            vSphereCloud vsC = findOurVsInstance();
+            vSphereCloud.Log(slaveComputer, taskListener, "Disconnect done.  Performing idle action %s...", localIdle);
+            final vSphereCloud vsC = findOurVsInstance();
             vsC.markVMOffline(slaveComputer.getDisplayName(), vmName);
-            v = vsC.vSphereInstance();
-            VirtualMachine vm = v.getVmByName(vmName);
-            if (vm != null && !MACHINE_ACTION.NOTHING.equals(localIdle)) {
+            final VirtualMachine vm;
+            if( !MACHINE_ACTION.NOTHING.equals(localIdle) ) {
+                v = vsC.vSphereInstance();
+                vm = v.getVmByName(vmName);
+            } else {
+                vm = null;
+            }
+            if (vm != null ) {
                 //VirtualMachinePowerState power = vm.getRuntime().getPowerState();
                 VirtualMachinePowerState power = vm.getSummary().getRuntime().powerState;
                 if (power == VirtualMachinePowerState.poweredOn) {
@@ -340,13 +345,15 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                         // VM is already powered down.
                 }
             }
-            if (v != null) {
-                v.disconnect();
-            }
+            vSphereCloud.Log(slaveComputer, taskListener, "Idle action %s complete.", localIdle);
         } catch (Throwable t) {
             vSphereCloud.Log(slaveComputer, taskListener, t, "Got an exception");
             taskListener.fatalError(t.getMessage(), t);
         } finally {
+            if (v != null) {
+                v.disconnect();
+                v = null;
+            }
             vsSlave.slaveIsDisconnecting = Boolean.FALSE;
             vsSlave.slaveIsStarting = Boolean.FALSE;
         }


### PR DESCRIPTION
vSphereCloudLauncher no longer connects to vSphere when its "idleAction" is "nothing".  It still connects as normal if it needs to, it just doesn't bother connecting when it's not going to use the connection.
It also now calls VSphere's disconnect method from a finally {...} block to ensure that it will always disconnect from vSphere if it had previously connected; before, it could remain connected if exceptions happened.
