### PR TITLE
[JENKINS-36952] Don't set env. variable if it's null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/vSphereStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/vSphereStep.java
@@ -122,7 +122,9 @@ public class vSphereStep extends AbstractStepImpl {
                     step.getBuildStep().getClass().toString().contains("Clone") ||
                     step.getBuildStep().getClass().toString().contains("ExposeGuestInfo")) {
                 IP = step.getBuildStep().getIP();
-                envVars.put("VSPHERE_IP", IP);
+                if (IP != null) {
+                    envVars.put("VSPHERE_IP", IP);
+                }
 
                 if (step.getBuildStep().getClass().toString().contains("ExposeGuestInfo")) {
                     Map<String, String> envVars = ((ExposeGuestInfo)step.getBuildStep()).getVars();


### PR DESCRIPTION
Don't set env. variable if it's null because it causes an exception in Jenkins 2 pipeline.
Fixes https://issues.jenkins-ci.org/browse/JENKINS-36952