### PR TITLE
[FIXED JENKINS-45786] Change idleMinutes to vsIdleMinutes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
@@ -10,16 +10,16 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public class VSphereCloudRetentionStrategy extends CloudRetentionStrategy {
 
-    private final int idleMinutes;
+    private final int vsIdleMinutes;
 
     @DataBoundConstructor
-    public VSphereCloudRetentionStrategy(int idleMinutes) {
-        super(idleMinutes);
-        this.idleMinutes = idleMinutes;
+    public VSphereCloudRetentionStrategy(int vsIdleMinutes) {
+        super(vsIdleMinutes);
+        this.vsIdleMinutes = vsIdleMinutes;
     }
 
-    public int getIdleMinutes() {
-        return idleMinutes;
+    public int getVsIdleMinutes() {
+        return vsIdleMinutes;
     }
 
     @Override

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy/config.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="${%Idle Timeout}" field="idleMinutes">
+    <f:entry title="${%Idle Timeout}" field="vsIdleMinutes">
         <f:number default="5"/>
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
This renames the VSphereCloudRetentionStrategy's idleMinutes field to vsIdleMinutes to prevent hiding the superclass field with the same name, which seems to have been preventing it from persisting properly across Jenkins restarts.  In my environment, this would lead to thrashing with short-lived jobs as nodes would go offline quickly instead of remaining available for reuse.  The workaround is to re-save the configuration via the web interface upon each Jenkins restart.