### PR TITLE
[FIXED JENKINS-45786] Add readResolve() to VSphereCloudRetentionStrategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
@@ -36,4 +36,9 @@ public class VSphereCloudRetentionStrategy extends CloudRetentionStrategy {
             return "vSphere Keep-Until-Idle Retention Strategy";
         }
     }
+    
+    private Object readResolve() {
+        // without this, super.idleMinutes is not restored from persistence
+        return new VSphereCloudRetentionStrategy(idleMinutes);
+    }
 }


### PR DESCRIPTION
to ensure super.idleMinutes is properly restored from persistent state