### PR TITLE
Minor code tidy-up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
             <name>Jason Swager</name>
             <email>jswager@alohaoi.com</email>
         </developer>
-			<developer>
+        <developer>
             <id>elordahl</id>
             <name>Eric Lordahl</name>
             <email>elordahl@vt.edu</email>
@@ -26,10 +26,10 @@
     </developers>
     <licenses>
         <license>
-	    <name>The Apache Software License, Version 2.0</name>
-	    <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-	    <distribution>repo</distribution>
-	    <comments>A business-friendly OSS license</comments>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
         </license>
      </licenses>
  

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -60,7 +60,6 @@ import org.jenkinsci.plugins.vsphere.VSphereCloudRetentionStrategy;
 import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
 import org.jenkinsci.plugins.vsphere.VSphereGuestInfoProperty;
 import org.jenkinsci.plugins.vsphere.builders.Messages;
-import org.jenkinsci.plugins.vsphere.tools.CloudProvisioningState;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereDuplicateException;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
@@ -200,7 +200,7 @@ public class VSphereBuildStepContainer extends Builder implements SimpleBuildSte
                 if (property instanceof FolderVSphereCloudProperty) {
 
                     FolderVSphereCloudProperty vSphereCloudProperty = (FolderVSphereCloudProperty) property;
-                    for (org.jenkinsci.plugins.vSphereCloud vSphereCloud : ((FolderVSphereCloudProperty) property).getClouds()) {
+                    for (org.jenkinsci.plugins.vSphereCloud vSphereCloud : vSphereCloudProperty.getClouds()) {
                         select.add(vSphereCloud.getVsDescription());
                     }
                     hasVsphereClouds = true;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Delete.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Delete.java
@@ -16,17 +16,14 @@ package org.jenkinsci.plugins.vsphere.builders;
 
 import hudson.*;
 import hudson.model.*;
-import hudson.tasks.BuildStepMonitor;
 import hudson.util.FormValidation;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Collection;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 
-import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.vsphere.VSphereBuildStep;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -14,7 +14,6 @@
  */
 package org.jenkinsci.plugins.vsphere.builders;
 
-import com.vmware.vim25.StringExpression;
 import hudson.*;
 import hudson.model.*;
 import hudson.tasks.BuildStepMonitor;
@@ -25,7 +24,6 @@ import java.io.PrintStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
@@ -39,7 +37,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import com.vmware.vim25.mo.VirtualMachine;
-import com.vmware.vim25.mo.VirtualMachineSnapshot;
 
 public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -43,50 +43,50 @@ import com.vmware.vim25.mo.VirtualMachineSnapshot;
 
 public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 
-	private final String template;
-	private final String clone;
-	private final boolean linkedClone;
-	private final String resourcePool;
-	private final String cluster;
+    private final String template;
+    private final String clone;
+    private final boolean linkedClone;
+    private final String resourcePool;
+    private final String cluster;
     private final String datastore;
     private final String folder;
     private final String customizationSpec;
     private final boolean powerOn;
-	private String IP;
+    private String IP;
 
-	@DataBoundConstructor
-	public Deploy(String template, String clone, boolean linkedClone,
-		      String resourcePool, String cluster, String datastore, String folder, String customizationSpec, boolean powerOn) throws VSphereException {
-		this.template = template;
-		this.clone = clone;
-		this.linkedClone = linkedClone;
-		this.resourcePool= (resourcePool != null) ? resourcePool : "";
-		this.cluster=cluster;
+    @DataBoundConstructor
+    public Deploy(String template, String clone, boolean linkedClone,
+            String resourcePool, String cluster, String datastore, String folder, String customizationSpec, boolean powerOn) throws VSphereException {
+        this.template = template;
+        this.clone = clone;
+        this.linkedClone = linkedClone;
+        this.resourcePool= (resourcePool != null) ? resourcePool : "";
+        this.cluster=cluster;
         this.datastore=datastore;
         this.folder=folder;
         this.customizationSpec=customizationSpec;
-		this.powerOn=powerOn;
-	}
+        this.powerOn=powerOn;
+    }
 
-	public String getTemplate() {
-		return template;
-	}
+    public String getTemplate() {
+        return template;
+    }
 
-	public String getClone() {
-		return clone;
-	}
+    public String getClone() {
+        return clone;
+    }
 
-	public boolean isLinkedClone() {
-		return linkedClone;
-	}
+    public boolean isLinkedClone() {
+        return linkedClone;
+    }
 
-	public String getCluster() {
-		return cluster;
-	}
+    public String getCluster() {
+        return cluster;
+    }
 
-	public String getResourcePool() {
-		return resourcePool;
-	}
+    public String getResourcePool() {
+        return resourcePool;
+    }
 
     public String getDatastore() {
         return datastore;
@@ -101,79 +101,79 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
     }
 
     public boolean isPowerOn() {
-	return powerOn;
+        return powerOn;
     }
 
-	@Override
-	public String getIP() {
-		return IP;
-	}
+    @Override
+    public String getIP() {
+        return IP;
+    }
 
-	@Override
-	public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-		try {
-			deployFromTemplate(run, launcher, listener);
-		} catch (Exception e) {
-			throw new AbortException(e.getMessage());
-		}
-	}
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        try {
+            deployFromTemplate(run, launcher, listener);
+        } catch (Exception e) {
+            throw new AbortException(e.getMessage());
+        }
+    }
 
-	@Override
-	public boolean prebuild(AbstractBuild<?, ?> abstractBuild, BuildListener buildListener) {
-		return false;
-	}
+    @Override
+    public boolean prebuild(AbstractBuild<?, ?> abstractBuild, BuildListener buildListener) {
+        return false;
+    }
 
-	@Override
-	public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)  {
-		boolean retVal = false;
-		try {
-			retVal = deployFromTemplate(build, launcher, listener);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return retVal;
-		//TODO throw AbortException instead of returning value
-	}
+    @Override
+    public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)  {
+        boolean retVal = false;
+        try {
+            retVal = deployFromTemplate(build, launcher, listener);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return retVal;
+        //TODO throw AbortException instead of returning value
+    }
 
-	@Override
-	public Action getProjectAction(AbstractProject<?, ?> abstractProject) {
-		return null;
-	}
+    @Override
+    public Action getProjectAction(AbstractProject<?, ?> abstractProject) {
+        return null;
+    }
 
-	@Override
-	public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> abstractProject) {
-		return null;
-	}
+    @Override
+    public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> abstractProject) {
+        return null;
+    }
 
-	@Override
-	public BuildStepMonitor getRequiredMonitorService() {
-		return null;
-	}
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return null;
+    }
 
-	private boolean deployFromTemplate(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws VSphereException {
-		PrintStream jLogger = listener.getLogger();
-		String expandedClone = clone;
-		String expandedTemplate = template;
-		String expandedCluster = cluster;
-		String expandedDatastore = datastore;
+    private boolean deployFromTemplate(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws VSphereException {
+        PrintStream jLogger = listener.getLogger();
+        String expandedClone = clone;
+        String expandedTemplate = template;
+        String expandedCluster = cluster;
+        String expandedDatastore = datastore;
                 String expandedFolder = folder;
                 String expandedCustomizationSpec = customizationSpec;
-		EnvVars env;
-		try {
-			env = run.getEnvironment(listener);
-		} catch (Exception e) {
-			throw new VSphereException(e);
-		}
+        EnvVars env;
+        try {
+            env = run.getEnvironment(listener);
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
 
-		if (run instanceof AbstractBuild) {
-			env.overrideAll(((AbstractBuild) run).getBuildVariables()); // Add in matrix axes..
-			expandedClone = env.expand(clone);
-			expandedTemplate = env.expand(template);
-			expandedCluster = env.expand(cluster);
-			expandedDatastore = env.expand(datastore);
+        if (run instanceof AbstractBuild) {
+            env.overrideAll(((AbstractBuild) run).getBuildVariables()); // Add in matrix axes..
+            expandedClone = env.expand(clone);
+            expandedTemplate = env.expand(template);
+            expandedCluster = env.expand(cluster);
+            expandedDatastore = env.expand(datastore);
                         expandedFolder = env.expand(folder);
                         expandedCustomizationSpec = env.expand(customizationSpec);
-		}
+        }
 
         String resourcePoolName;
         if ("".equals(resourcePool) || (resourcePool.length() == 0)) {
@@ -185,119 +185,120 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
         }
 
         vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, jLogger);
-		VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
-		if (!powerOn) {
-			return true; // don't try to obtain IP if VM isn't being turned on.
-		}
-		IP = vsphere.getIp(vsphere.getVmByName(expandedClone), 60);
+        VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
+        if (!powerOn) {
+            return true; // don't try to obtain IP if VM isn't being turned on.
+        }
+        IP = vsphere.getIp(vsphere.getVmByName(expandedClone), 60);
 
-		if(IP!=null) {
-			VSphereLogger.vsLogger(jLogger, "Successfully retrieved IP for \"" + expandedClone + "\" : " + IP);
-			VSphereLogger.vsLogger(jLogger, "Exposing " + IP + " as environment variable VSPHERE_IP");
+        if (IP!=null) {
+            VSphereLogger.vsLogger(jLogger, "Successfully retrieved IP for \"" + expandedClone + "\" : " + IP);
+            VSphereLogger.vsLogger(jLogger, "Exposing " + IP + " as environment variable VSPHERE_IP");
 
-			if (run instanceof AbstractBuild) {
-				VSphereEnvAction envAction = new VSphereEnvAction();
-				envAction.add("VSPHERE_IP", IP);
-				run.addAction(envAction);
-			}
+            if (run instanceof AbstractBuild) {
+                VSphereEnvAction envAction = new VSphereEnvAction();
+                envAction.add("VSPHERE_IP", IP);
+                run.addAction(envAction);
+            }
 
-			return true;
-		} else {
-			VSphereLogger.vsLogger(jLogger, "Error: Timed out after waiting 60 seconds to get IP for \""+expandedClone+"\" ");
-			return false;
-		}
-	}
+            return true;
+        } else {
+            VSphereLogger.vsLogger(jLogger, "Error: Timed out after waiting 60 seconds to get IP for \""+expandedClone+"\" ");
+            return false;
+        }
+    }
 
-	@Extension
-	public static final class DeployDescriptor extends VSphereBuildStepDescriptor {
+    @Extension
+    public static final class DeployDescriptor extends VSphereBuildStepDescriptor {
 
-		public DeployDescriptor() {
-			load();
-		}
+        public DeployDescriptor() {
+            load();
+        }
 
-		@Override
-		public String getDisplayName() {
-			return Messages.vm_title_Deploy();
-		}
+        @Override
+        public String getDisplayName() {
+            return Messages.vm_title_Deploy();
+        }
 
-		public FormValidation doCheckTemplate(@QueryParameter String value)
-				throws IOException, ServletException {
-			if (value.length() == 0)
-				return FormValidation.error("Please enter the template name");
-			return FormValidation.ok();
-		}
+        public FormValidation doCheckTemplate(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error("Please enter the template name");
+            return FormValidation.ok();
+        }
 
-		public FormValidation doCheckClone(@QueryParameter String value)
-				throws IOException, ServletException {
-			if (value.length() == 0)
-				return FormValidation.error(Messages.validation_required("the clone name"));
-			return FormValidation.ok();
-		}
+        public FormValidation doCheckClone(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Messages.validation_required("the clone name"));
+            return FormValidation.ok();
+        }
 
-		public FormValidation doCheckResourcePool(@QueryParameter String value)
-				throws IOException, ServletException {
-			return FormValidation.ok();
-		}
+        public FormValidation doCheckResourcePool(@QueryParameter String value)
+                throws IOException, ServletException {
+            return FormValidation.ok();
+        }
 
-		public FormValidation doCheckCluster(@QueryParameter String value)
-				throws IOException, ServletException {
-			if (value.length() == 0)
-				return FormValidation.error(Messages.validation_required("the cluster"));
-			return FormValidation.ok();
-		}
+        public FormValidation doCheckCluster(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Messages.validation_required("the cluster"));
+            return FormValidation.ok();
+        }
 
-		public FormValidation doTestData(@QueryParameter String serverName,
-				@QueryParameter String template, @QueryParameter String clone,
-				@QueryParameter String resourcePool, @QueryParameter String cluster) {
-			try {
-				if (template.length() == 0 || clone.length()==0 || serverName.length()==0
-						|| cluster.length()==0 )
-					return FormValidation.error(Messages.validation_requiredValues());
+        public FormValidation doTestData(@QueryParameter String serverName,
+                @QueryParameter String template, @QueryParameter String clone,
+                @QueryParameter String resourcePool, @QueryParameter String cluster) {
+            try {
+                if (template.length() == 0 || clone.length()==0 || serverName.length()==0
+                        || cluster.length()==0 )
+                    return FormValidation.error(Messages.validation_requiredValues());
 
-				VSphere vsphere = getVSphereCloudByName(serverName, null).vSphereInstance();
+                VSphere vsphere = getVSphereCloudByName(serverName, null).vSphereInstance();
 
-				//TODO what if clone name is variable?
-				VirtualMachine cloneVM = vsphere.getVmByName(clone);
-				if (cloneVM != null)
-					return FormValidation.error(Messages.validation_exists("clone"));
+                //TODO what if clone name is variable?
+                VirtualMachine cloneVM = vsphere.getVmByName(clone);
+                if (cloneVM != null)
+                    return FormValidation.error(Messages.validation_exists("clone"));
 
-				if (template.indexOf('$') >= 0)
-					return FormValidation.warning(Messages.validation_buildParameter("template"));
+                if (template.indexOf('$') >= 0)
+                    return FormValidation.warning(Messages.validation_buildParameter("template"));
 
-				VirtualMachine vm = vsphere.getVmByName(template);
-				if (vm == null)
-					return FormValidation.error(Messages.validation_notFound("template"));
+                VirtualMachine vm = vsphere.getVmByName(template);
+                if (vm == null)
+                    return FormValidation.error(Messages.validation_notFound("template"));
 
-				if(!vm.getConfig().template)
-					return FormValidation.error(Messages.validation_notActually("template"));
+                if(!vm.getConfig().template)
+                    return FormValidation.error(Messages.validation_notActually("template"));
 
-				return FormValidation.ok(Messages.validation_success());
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-	}
-	/**
-	 * This class is used to inject the IP value into the build environment
-	 * as a variable so that it can be used with other plugins. (Copied from PowerOn builder)
-	 *
-	 * @author Lordahl
-	 */
-	private static class VSphereEnvAction implements EnvironmentContributingAction {
-		// Decided not to record this data in build.xml, so marked transient:
-		private transient Map<String,String> data = new HashMap<String,String>();
+                return FormValidation.ok(Messages.validation_success());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
-		private void add(String key, String val) {
-			if (data==null) return;
-			data.put(key, val);
-		}
+    /**
+     * This class is used to inject the IP value into the build environment
+     * as a variable so that it can be used with other plugins. (Copied from PowerOn builder)
+     *
+     * @author Lordahl
+     */
+    private static class VSphereEnvAction implements EnvironmentContributingAction {
+        // Decided not to record this data in build.xml, so marked transient:
+        private transient Map<String,String> data = new HashMap<String,String>();
 
-		public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
-			if (data!=null) env.putAll(data);
-		}
+        private void add(String key, String val) {
+            if (data==null) return;
+            data.put(key, val);
+        }
 
-		public String getIconFileName() { return null; }
-		public String getDisplayName() { return null; }
-		public String getUrlName() { return null; }
-	}
+        public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
+            if (data!=null) env.putAll(data);
+        }
+
+        public String getIconFileName() { return null; }
+        public String getDisplayName() { return null; }
+        public String getUrlName() { return null; }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/PowerOff.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/PowerOff.java
@@ -16,7 +16,6 @@ package org.jenkinsci.plugins.vsphere.builders;
 
 import hudson.*;
 import hudson.model.*;
-import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepMonitor;
 import hudson.util.FormValidation;
 

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureCpu.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureCpu.java
@@ -14,7 +14,6 @@
  */
 package org.jenkinsci.plugins.vsphere.builders;
 
-import com.vmware.vim25.*;
 import hudson.*;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
@@ -31,7 +30,6 @@ import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Arrays;
 
 public class ReconfigureCpu extends ReconfigureStep {
 

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureMemory.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureMemory.java
@@ -14,10 +14,6 @@
  */
 package org.jenkinsci.plugins.vsphere.builders;
 
-import com.vmware.vim25.ResourceAllocationInfo;
-import com.vmware.vim25.SharesInfo;
-import com.vmware.vim25.VirtualDevice;
-import com.vmware.vim25.VirtualEthernetCard;
 import hudson.*;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -65,35 +65,35 @@ import com.vmware.vim25.mo.DistributedVirtualPortgroup;
 import com.vmware.vim25.mo.DistributedVirtualSwitch;
 
 public class VSphere {
-	private final URL url;
-	private final String session;
-	private final static Logger LOGGER = Logger.getLogger(VSphere.class.getName());
+    private final URL url;
+    private final String session;
+    private final static Logger LOGGER = Logger.getLogger(VSphere.class.getName());
 
-	private VSphere(@Nonnull String url, @Nonnull String user, @CheckForNull String pw) throws VSphereException{
-		try {
-			//TODO - change ignoreCert to be configurable
-			this.url = new URL(url);
-			this.session = (new ServiceInstance(this.url, user, pw, true)).getServerConnection().getSessionStr();
-		} catch (Exception e) {
-			throw new VSphereException(e);
-		}
-	}
+    private VSphere(@Nonnull String url, @Nonnull String user, @CheckForNull String pw) throws VSphereException {
+        try {
+            //TODO - change ignoreCert to be configurable
+            this.url = new URL(url);
+            this.session = (new ServiceInstance(this.url, user, pw, true)).getServerConnection().getSessionStr();
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
+    }
 
-	private ServiceInstance getServiceInstance() throws RemoteException, MalformedURLException{
-		return new ServiceInstance(url, session, true);
-	}
+    private ServiceInstance getServiceInstance() throws RemoteException, MalformedURLException {
+        return new ServiceInstance(url, session, true);
+    }
 
-	/**
-	 * Initiates Connection to vSphere Server
-         * @param server Server URL
-	 * @param user Username.
-	 * @param pw Password.
-	 * @throws VSphereException If an error occurred.
-	 * @return A connected instance.
-	 */
-	public static VSphere connect(@Nonnull String server, @Nonnull String user, @CheckForNull String pw) throws VSphereException {
-		return new VSphere(server, user, pw);
-	}
+    /**
+     * Initiates Connection to vSphere Server
+     * @param server Server URL
+     * @param user Username.
+     * @param pw Password.
+     * @throws VSphereException If an error occurred.
+     * @return A connected instance.
+     */
+    public static VSphere connect(@Nonnull String server, @Nonnull String user, @CheckForNull String pw) throws VSphereException {
+        return new VSphere(server, user, pw);
+    }
 
     /**
      * Disconnect from vSphere server.
@@ -192,12 +192,12 @@ public class VSphere {
      *             if anything goes wrong.
      */
     public void cloneOrDeployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean useCurrentSnapshot, final String namedSnapshot, boolean powerOn, String customizationSpec, PrintStream jLogger) throws VSphereException {
-        try{
+        try {
             final VirtualMachine sourceVm = getVmByName(sourceName);
-            if(sourceVm==null) {
+            if (sourceVm==null) {
                 throw new VSphereNotFoundException("VM or template", sourceName);
             }
-            if(getVmByName(cloneName)!=null){
+            if (getVmByName(cloneName)!=null) {
                 throw new VSphereDuplicateException("VM", cloneName);
             }
 
@@ -222,14 +222,14 @@ public class VSphere {
             }
             if (useCurrentSnapshot) {
                 final VirtualMachineSnapshot currentSnapShot = sourceVm.getCurrentSnapShot();
-                if(currentSnapShot==null){
+                if (currentSnapShot==null) {
                     throw new VSphereNotFoundException("Snapshot", null, "Source " + sourceType + "  \"" + sourceName + "\" requires at least one snapshot.");
                 }
                 logMessage(jLogger, "Clone of " + sourceType + " \"" + sourceName + "\" will be based on current snapshot \"" + currentSnapShot.toString() + "\".");
                 cloneSpec.setSnapshot(currentSnapShot.getMOR());
             }
 
-            if(customizationSpec != null && customizationSpec.length() > 0) {
+            if (customizationSpec != null && customizationSpec.length() > 0) {
                 logMessage(jLogger, "Clone of " + sourceType + " \"" + sourceName + "\" will use customization specification \"" + customizationSpec + "\".");
                 CustomizationSpecItem spec = getCustomizationSpecByName(customizationSpec);
                 cloneSpec.setCustomization(spec.getSpec());
@@ -251,14 +251,14 @@ public class VSphere {
             logMessage(jLogger, "Started cloning of " + sourceType + " \"" + sourceName + "\". Please wait ...");
 
             final String status = task.waitForTask();
-            if(!TaskInfoState.success.toString().equals(status)) {
+            if (!TaskInfoState.success.toString().equals(status)) {
                 throw newVSphereException(task.getTaskInfo(), "Couldn't clone \""+ sourceName +"\". " +
                         "Clone task ended with status " + status + ".");
             }
             logMessage(jLogger, "Successfully cloned VM \"" + sourceName + "\" to create \"" + cloneName + "\".");
-        } catch(RuntimeException | VSphereException e){
+        } catch(RuntimeException | VSphereException e) {
             throw e;
-        } catch(Exception e){
+        } catch(Exception e) {
             throw new VSphereException(e);
         }
     }
@@ -272,12 +272,12 @@ public class VSphere {
     }
 
     private VirtualMachineRelocateSpec createRelocateSpec(PrintStream jLogger, boolean linkedClone, String resourcePoolName,
-                                                          String cluster, String datastoreName, boolean isResourcePoolRequired) throws RemoteException, MalformedURLException, VSphereException {
+            String cluster, String datastoreName, boolean isResourcePoolRequired) throws RemoteException, MalformedURLException, VSphereException {
         VirtualMachineRelocateSpec rel  = new VirtualMachineRelocateSpec();
 
-        if(linkedClone){
+        if (linkedClone) {
             rel.setDiskMoveType("createNewChildDiskBacking");
-        }else{
+        } else {
             rel.setDiskMoveType("moveAllDiskBackingsAndDisallowSharing");
         }
 
@@ -289,20 +289,18 @@ public class VSphere {
         }
 
         if (resourcePoolName != null && !resourcePoolName.isEmpty()) {
-        	ResourcePool resourcePool = getResourcePoolByName(resourcePoolName, clusterResource);
-
-        	if (resourcePool == null) {
-        		throw new VSphereNotFoundException("Resource pool", resourcePoolName);
-        	}
-
-        	rel.setPool(resourcePool.getMOR());
+            ResourcePool resourcePool = getResourcePoolByName(resourcePoolName, clusterResource);
+            if (resourcePool == null) {
+                throw new VSphereNotFoundException("Resource pool", resourcePoolName);
+            }
+            rel.setPool(resourcePool.getMOR());
         } else if (isResourcePoolRequired) {
-    		throw new VSphereException("You must specify a resource  pool  when using a template");
+            throw new VSphereException("You must specify a resource  pool  when using a template");
         }
 
         if (datastoreName != null && !datastoreName.isEmpty()) {
             Datastore datastore = getDatastoreByName(datastoreName, clusterResource);
-            if (datastore==null){
+            if (datastore==null) {
                 throw new VSphereNotFoundException("Datastore", datastoreName);
             }
             rel.setDatastore(datastore.getMOR());
@@ -312,319 +310,314 @@ public class VSphere {
 
     public void reconfigureVm(String name, VirtualMachineConfigSpec spec) throws VSphereException {
         VirtualMachine vm = getVmByName(name);
-        if(vm==null) {
+        if (vm==null) {
             throw new VSphereNotFoundException("VM or template", name);
         }
         LOGGER.log(Level.FINER, "Reconfiguring VM. Please wait ...");
         try {
             Task task = vm.reconfigVM_Task(spec);
             String status = task.waitForTask();
-            if(status.equals(TaskInfoState.success.toString())) {
+            if (status.equals(TaskInfoState.success.toString())) {
                 return;
             }
             throw newVSphereException(task.getTaskInfo(), "Couldn't reconfigure \""+ name +"\"!");
-        } catch(RuntimeException | VSphereException e){
+        } catch(RuntimeException | VSphereException e) {
             throw e;
-        } catch(Exception e){
+        } catch(Exception e) {
             throw new VSphereException("VM cannot be reconfigured:" + e.getMessage(), e);
         }
     }
 
-	/**
-	 * @param name - Name of VM to start
-	 * @param timeoutInSeconds How long to wait for the VM to be running.
-	 * @throws VSphereException If an error occurred.
-	 */
-	public void startVm(String name, int timeoutInSeconds) throws VSphereException {
-		try{
-			VirtualMachine vm = getVmByName(name);
+    /**
+     * @param name - Name of VM to start
+     * @param timeoutInSeconds How long to wait for the VM to be running.
+     * @throws VSphereException If an error occurred.
+     */
+    public void startVm(String name, int timeoutInSeconds) throws VSphereException {
+        try {
+            VirtualMachine vm = getVmByName(name);
             if (vm == null) {
                 throw new VSphereNotFoundException("VM", name);
             }
-			if(isPoweredOn(vm))
-				return;
+            if (isPoweredOn(vm))
+                return;
 
-			if(vm.getConfig().template)
-				throw new VSphereException("VM represents a template!");
+            if (vm.getConfig().template)
+                throw new VSphereException("VM represents a template!");
 
-			Task task = vm.powerOnVM_Task(null);
+            Task task = vm.powerOnVM_Task(null);
 
             int timesToCheck = timeoutInSeconds / 5;
             // add one extra time for remainder
             timesToCheck++;
             LOGGER.log(Level.FINER, "Checking " + timesToCheck + " times for vm to be powered on");
 
-			for (int i=0; i<timesToCheck; i++){
-
-				if(task.getTaskInfo().getState()==TaskInfoState.success){
+            for (int i=0; i<timesToCheck; i++) {
+                if (task.getTaskInfo().getState()==TaskInfoState.success) {
                     LOGGER.log(Level.FINER, "VM was powered up successfully.");
                     return;
-				}
-
-				if (task.getTaskInfo().getState()==TaskInfoState.running ||
-						task.getTaskInfo().getState()==TaskInfoState.queued){
-					Thread.sleep(5000);
-				}
-
-				//Check for copied/moved question
-				VirtualMachineQuestionInfo q = vm.getRuntime().getQuestion();
-				if(q!=null && q.getId().equals("_vmx1")){
-					vm.answerVM(q.getId(), q.getChoice().getDefaultIndex().toString());
+                }
+                if (task.getTaskInfo().getState()==TaskInfoState.running ||
+                        task.getTaskInfo().getState()==TaskInfoState.queued) {
+                    Thread.sleep(5000);
+                }
+                //Check for copied/moved question
+                VirtualMachineQuestionInfo q = vm.getRuntime().getQuestion();
+                if (q!=null && q.getId().equals("_vmx1")) {
+                    vm.answerVM(q.getId(), q.getChoice().getDefaultIndex().toString());
                     return;
-				}
-			}
-		}catch(InterruptedException e){ // build aborted
-			Thread.currentThread().interrupt(); // pass interrupt upwards
-			throw new VSphereException("VM cannot be started: " + e.getMessage(), e);
-		}catch(Exception e){
-			throw new VSphereException("VM cannot be started: " + e.getMessage(), e);
-		}
+                }
+            }
+        } catch(InterruptedException e) { // build aborted
+            Thread.currentThread().interrupt(); // pass interrupt upwards
+            throw new VSphereException("VM cannot be started: " + e.getMessage(), e);
+        } catch(Exception e) {
+            throw new VSphereException("VM cannot be started: " + e.getMessage(), e);
+        }
 
-		throw new VSphereException("VM cannot be started");
-	}
+        throw new VSphereException("VM cannot be started");
+    }
 
-	private ManagedObjectReference findSnapshotInTree(
-			VirtualMachineSnapshotTree[] snapTree, String snapName) {
-		LOGGER.log(Level.FINER, "Looking for snapshot " + snapName);
-		for (VirtualMachineSnapshotTree node : snapTree) {
-			if (snapName.equals(node.getName())) {
-				return node.getSnapshot();
-			} else {
-				VirtualMachineSnapshotTree[] childTree =
-						node.getChildSnapshotList();
-				if (childTree != null) {
-					ManagedObjectReference mor = findSnapshotInTree(
-							childTree, snapName);
-					if (mor != null) {
-						return mor;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    private ManagedObjectReference findSnapshotInTree(
+            VirtualMachineSnapshotTree[] snapTree, String snapName) {
+        LOGGER.log(Level.FINER, "Looking for snapshot " + snapName);
+        for (VirtualMachineSnapshotTree node : snapTree) {
+            if (snapName.equals(node.getName())) {
+                return node.getSnapshot();
+            } else {
+                VirtualMachineSnapshotTree[] childTree =
+                        node.getChildSnapshotList();
+                if (childTree != null) {
+                    ManagedObjectReference mor = findSnapshotInTree(
+                            childTree, snapName);
+                    if (mor != null) {
+                        return mor;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	public VirtualMachineSnapshot getSnapshotInTree(
-			VirtualMachine vm, String snapName) {
-		if (vm == null || snapName == null) {
-			return null;
-		}
+    public VirtualMachineSnapshot getSnapshotInTree(
+            VirtualMachine vm, String snapName) {
+        if (vm == null || snapName == null) {
+            return null;
+        }
 
-		LOGGER.log(Level.FINER, "Looking for snapshot " + snapName + " in " + vm.getName() );
-		VirtualMachineSnapshotInfo info = vm.getSnapshot();
-		if (info != null)
-		{
-			VirtualMachineSnapshotTree[] snapTree =
-					info.getRootSnapshotList();
-			if (snapTree != null) {
-				ManagedObjectReference mor = findSnapshotInTree(
-						snapTree, snapName);
-				if (mor != null) {
-					return new VirtualMachineSnapshot(
-							vm.getServerConnection(), mor);
-				}
-			}
-		}
+        LOGGER.log(Level.FINER, "Looking for snapshot " + snapName + " in " + vm.getName() );
+        VirtualMachineSnapshotInfo info = vm.getSnapshot();
+        if (info != null) {
+            VirtualMachineSnapshotTree[] snapTree =
+                    info.getRootSnapshotList();
+            if (snapTree != null) {
+                ManagedObjectReference mor = findSnapshotInTree(
+                        snapTree, snapName);
+                if (mor != null) {
+                    return new VirtualMachineSnapshot(
+                            vm.getServerConnection(), mor);
+                }
+            }
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	public void revertToSnapshot(String vmName, String snapName) throws VSphereException{
+    public void revertToSnapshot(String vmName, String snapName) throws VSphereException {
 
-		VirtualMachine vm = getVmByName(vmName);
-		VirtualMachineSnapshot snap = getSnapshotInTree(vm, snapName);
+        VirtualMachine vm = getVmByName(vmName);
+        VirtualMachineSnapshot snap = getSnapshotInTree(vm, snapName);
 
-		if (snap == null) {
-			LOGGER.log(Level.SEVERE, "Cannot find snapshot: '" + snapName + "' for virtual machine: '" + vm.getName()+"'");
-			throw new VSphereNotFoundException("Snapshot", snapName);
-		}
+        if (snap == null) {
+            LOGGER.log(Level.SEVERE, "Cannot find snapshot: '" + snapName + "' for virtual machine: '" + vm.getName()+"'");
+            throw new VSphereNotFoundException("Snapshot", snapName);
+        }
 
-		try{
-			Task task = snap.revertToSnapshot_Task(null);
-			if (!task.waitForTask().equals(Task.SUCCESS)) {
-				final String msg = "Could not revert to snapshot '" + snap.toString() + "' for virtual machine:'" + vm.getName()+"'";
-				LOGGER.log(Level.SEVERE, msg);
-				throw newVSphereException(task.getTaskInfo(), msg);
-			}
-		} catch(RuntimeException | VSphereException e){
-			throw e;
-		}catch(Exception e){
-			throw new VSphereException(e);
-		}
-	}
+        try {
+            Task task = snap.revertToSnapshot_Task(null);
+            if (!task.waitForTask().equals(Task.SUCCESS)) {
+                final String msg = "Could not revert to snapshot '" + snap.toString() + "' for virtual machine:'" + vm.getName()+"'";
+                LOGGER.log(Level.SEVERE, msg);
+                throw newVSphereException(task.getTaskInfo(), msg);
+            }
+        } catch(RuntimeException | VSphereException e) {
+            throw e;
+        } catch(Exception e) {
+            throw new VSphereException(e);
+        }
+    }
 
-	public void deleteSnapshot(String vmName, String snapName, boolean consolidate, boolean failOnNoExist) throws VSphereException{
+    public void deleteSnapshot(String vmName, String snapName, boolean consolidate, boolean failOnNoExist) throws VSphereException {
 
-		VirtualMachine vm = getVmByName(vmName);
-		VirtualMachineSnapshot snap = getSnapshotInTree(vm, snapName);
+        VirtualMachine vm = getVmByName(vmName);
+        VirtualMachineSnapshot snap = getSnapshotInTree(vm, snapName);
 
-		if (snap == null && failOnNoExist) {
-			throw new VSphereNotFoundException("Snapshot", snapName);
-		}
+        if (snap == null && failOnNoExist) {
+            throw new VSphereNotFoundException("Snapshot", snapName);
+        }
 
-		try{
+        try {
+            Task task;
+            if (snap!=null) {
+                //Does not delete subtree; Implicitly consolidates disk
+                task = snap.removeSnapshot_Task(false);
+                if (!task.waitForTask().equals(Task.SUCCESS)) {
+                    throw newVSphereException(task.getTaskInfo(), "Could not delete snapshot");
+                }
+            }
 
-			Task task;
-			if (snap!=null){
-				//Does not delete subtree; Implicitly consolidates disk
-				task = snap.removeSnapshot_Task(false);
-				if (!task.waitForTask().equals(Task.SUCCESS)) {
-					throw newVSphereException(task.getTaskInfo(), "Could not delete snapshot");
-				}
-			}
+            if (!consolidate)
+                return;
 
-			if(!consolidate)
-				return;
+            //This might be redundant, but I think it consolidates all disks,
+            //where as the removeSnapshot only consolidates the individual disk
+            task = vm.consolidateVMDisks_Task();
+            if (!task.waitForTask().equals(Task.SUCCESS)) {
+                throw newVSphereException(task.getTaskInfo(), "Could not consolidate VM disks");
+            }
+        } catch(RuntimeException | VSphereException e) {
+            throw e;
+        } catch(Exception e) {
+            throw new VSphereException(e);
+        }
+    }
 
-			//This might be redundant, but I think it consolidates all disks,
-			//where as the removeSnapshot only consolidates the individual disk
-			task = vm.consolidateVMDisks_Task();
-			if (!task.waitForTask().equals(Task.SUCCESS)) {
-				throw newVSphereException(task.getTaskInfo(), "Could not consolidate VM disks");
-			}
-		} catch(RuntimeException | VSphereException e){
-			throw e;
-		}catch(Exception e){
-			throw new VSphereException(e);
-		}
-	}
-
-	public void takeSnapshot(String vmName, String snapshot, String description, boolean snapMemory) throws VSphereException{
+    public void takeSnapshot(String vmName, String snapshot, String description, boolean snapMemory) throws VSphereException {
 
         final String message = "Could not take snapshot";
-            VirtualMachine vmToSnapshot = getVmByName(vmName);
-            if (vmToSnapshot == null) {
-                throw new VSphereNotFoundException("VM", vmName);
-            }
+        VirtualMachine vmToSnapshot = getVmByName(vmName);
+        if (vmToSnapshot == null) {
+            throw new VSphereNotFoundException("VM", vmName);
+        }
         try {
-			Task task = vmToSnapshot.createSnapshot_Task(snapshot, description, snapMemory, !snapMemory);
-			if (task.waitForTask().equals(Task.SUCCESS)) {
-				return;
-			}
-			throw newVSphereException(task.getTaskInfo(), message);
-		} catch(RuntimeException | VSphereException e){
-			throw e;
-		} catch (Exception e) {
+            Task task = vmToSnapshot.createSnapshot_Task(snapshot, description, snapMemory, !snapMemory);
+            if (task.waitForTask().equals(Task.SUCCESS)) {
+                return;
+            }
+            throw newVSphereException(task.getTaskInfo(), message);
+        } catch(RuntimeException | VSphereException e) {
+            throw e;
+        } catch (Exception e) {
             throw new VSphereException(message, e);
         }
-	}
+    }
 
-	public void markAsTemplate(String vmName, String snapName, boolean force) throws VSphereException {
+    public void markAsTemplate(String vmName, String snapName, boolean force) throws VSphereException {
 
-		final String message = "Could not mark as Template. Check it's power state or select \"force.\"";
-		try{
-			VirtualMachine vm = getVmByName(vmName);
-			if(vm.getConfig().template)
-				return;
+        final String message = "Could not mark as Template. Check it's power state or select \"force.\"";
+        try {
+            VirtualMachine vm = getVmByName(vmName);
+            if (vm.getConfig().template)
+                return;
 
-			if(isPoweredOff(vm) || force){
-				powerOffVm(vm, force, false);
-				vm.markAsTemplate();
-				return;
-			}
-		}catch(Exception e){
-			throw new VSphereException(message, e);
-		}
-		throw new VSphereException(message);
-	}
+            if (isPoweredOff(vm) || force) {
+                powerOffVm(vm, force, false);
+                vm.markAsTemplate();
+                return;
+            }
+        } catch(Exception e) {
+            throw new VSphereException(message, e);
+        }
+        throw new VSphereException(message);
+    }
 
-	public void markAsVm(String name, String resourcePool, String cluster) throws VSphereException{
-		try{
-			VirtualMachine vm = getVmByName(name);
-			if(vm.getConfig().template){
-				vm.markAsVirtualMachine(
-						getResourcePoolByName(resourcePool, getClusterByName(cluster)),
-						null
-						);
-			}
-		}catch(Exception e){
-			throw new VSphereException("Could not convert to VM", e);
-		}
-	}
+    public void markAsVm(String name, String resourcePool, String cluster) throws VSphereException {
+        try {
+            VirtualMachine vm = getVmByName(name);
+            if (vm.getConfig().template) {
+                vm.markAsVirtualMachine(
+                        getResourcePoolByName(resourcePool, getClusterByName(cluster)),
+                        null
+                        );
+            }
+        } catch(Exception e) {
+            throw new VSphereException("Could not convert to VM", e);
+        }
+    }
 
-	/**
-	 * Asks vSphere for the IP address used by a VM.
-	 * 
-	 * @param vm VirtualMachine name whose IP is to be returned.
-	 * @param timeout How long to wait (in seconds) for the IP address to known to vSphere.
-	 * @return String containing IP address.
-	 * @throws VSphereException If an error occurred.
-	 */
-	public String getIp(VirtualMachine vm, int timeout) throws VSphereException {
+    /**
+     * Asks vSphere for the IP address used by a VM.
+     * 
+     * @param vm VirtualMachine name whose IP is to be returned.
+     * @param timeout How long to wait (in seconds) for the IP address to known to vSphere.
+     * @return String containing IP address.
+     * @throws VSphereException If an error occurred.
+     */
+    public String getIp(VirtualMachine vm, int timeout) throws VSphereException {
 
-		if (vm==null)
-			throw new VSphereException("VM is null");
+        if (vm==null)
+            throw new VSphereException("VM is null");
 
-		//Determine how many attempts will be made to fetch the IP address
-		final int waitSeconds = 5;
-		final int maxTries;
-		if (timeout<=waitSeconds)
-			maxTries = 1;
-		else
-			maxTries = (int) Math.round((double)timeout / waitSeconds);
+        //Determine how many attempts will be made to fetch the IP address
+        final int waitSeconds = 5;
+        final int maxTries;
+        if (timeout<=waitSeconds)
+            maxTries = 1;
+        else
+            maxTries = (int) Math.round((double)timeout / waitSeconds);
 
-		for(int count=0; count<maxTries; count++){
+        for(int count=0; count<maxTries; count++) {
 
             GuestInfo guestInfo = vm.getGuest();
 
             // guest info can be null sometimes
-			if (guestInfo != null && guestInfo.getIpAddress() != null){
-				return guestInfo.getIpAddress();
-			}
-
-			try {
-				//wait
-				Thread.sleep(waitSeconds * 1000);
-			} catch (InterruptedException e) { // build aborted
-				Thread.currentThread().interrupt(); // pass interrupt upwards
-				break; // and abort our activities now.
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * @param vmName - name of VM object to retrieve
-	 * @return - VirtualMachine object
-	 * @throws VSphereException If an error occurred.
-	 */
-	public VirtualMachine getVmByName(String vmName) throws VSphereException {
-		try {
-			return (VirtualMachine) new InventoryNavigator(
-					getServiceInstance().getRootFolder()).searchManagedEntity(
-							"VirtualMachine", vmName);
-		} catch (Exception e) {
-			throw new VSphereException(e);
-		}
-	}
-
-        public int countVms() throws VSphereException {
-            int count = 0;
-            try {
-                final InventoryNavigator navigator = new InventoryNavigator(getServiceInstance().getRootFolder());
-                final ManagedEntity[] entities = navigator.searchManagedEntities(false);
-                count = entities.length;
-            } catch (Exception ex) {
-                throw new VSphereException(ex);
+            if (guestInfo != null && guestInfo.getIpAddress() != null) {
+                return guestInfo.getIpAddress();
             }
-            return count;
-        }
 
-        public int countVmsByPrefix(final String prefix) throws VSphereException {
-            int count = 0;
             try {
-                final InventoryNavigator navigator = new InventoryNavigator(getServiceInstance().getRootFolder());
-                final ManagedEntity[] entities = navigator.searchManagedEntities(false);
-                for(final ManagedEntity entity : entities) {
-                    if(entity.getName().startsWith(prefix)) {
-                        ++count;
-                    }
+                //wait
+                Thread.sleep(waitSeconds * 1000);
+            } catch (InterruptedException e) { // build aborted
+                Thread.currentThread().interrupt(); // pass interrupt upwards
+                break; // and abort our activities now.
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param vmName - name of VM object to retrieve
+     * @return - VirtualMachine object
+     * @throws VSphereException If an error occurred.
+     */
+    public VirtualMachine getVmByName(String vmName) throws VSphereException {
+        try {
+            return (VirtualMachine) new InventoryNavigator(
+                    getServiceInstance().getRootFolder()).searchManagedEntity(
+                            "VirtualMachine", vmName);
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
+    }
+
+    public int countVms() throws VSphereException {
+        int count = 0;
+        try {
+            final InventoryNavigator navigator = new InventoryNavigator(getServiceInstance().getRootFolder());
+            final ManagedEntity[] entities = navigator.searchManagedEntities(false);
+            count = entities.length;
+        } catch (Exception ex) {
+            throw new VSphereException(ex);
+        }
+        return count;
+    }
+
+    public int countVmsByPrefix(final String prefix) throws VSphereException {
+        int count = 0;
+        try {
+            final InventoryNavigator navigator = new InventoryNavigator(getServiceInstance().getRootFolder());
+            final ManagedEntity[] entities = navigator.searchManagedEntities(false);
+            for(final ManagedEntity entity : entities) {
+                if (entity.getName().startsWith(prefix)) {
+                    ++count;
                 }
-            } catch (Exception ex) {
-                throw new VSphereException(ex);
             }
-            return count;
+        } catch (Exception ex) {
+            throw new VSphereException(ex);
         }
+        return count;
+    }
 
     private Datastore getDatastoreByName(final String datastoreName, ManagedEntity rootEntity) throws RemoteException, MalformedURLException {
         if (rootEntity == null) {
@@ -708,104 +701,102 @@ public class VSphere {
         }
     }
 
-	/**
-	 * @return - ManagedEntity array of Datastore
-	 * @throws VSphereException If an error occurred.
-	 */
-	public ManagedEntity[] getDatastores() throws VSphereException {
-		try {
-			return new InventoryNavigator(
-					getServiceInstance().getRootFolder()).searchManagedEntities(
-							"Datastore");
-		} catch (Exception e) {
-			throw new VSphereException(e);
-		}
-	}
+    /**
+     * @return - ManagedEntity array of Datastore
+     * @throws VSphereException If an error occurred.
+     */
+    public ManagedEntity[] getDatastores() throws VSphereException {
+        try {
+            return new InventoryNavigator(
+                    getServiceInstance().getRootFolder()).searchManagedEntities(
+                            "Datastore");
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
+    }
 
-	/**
-	 * @param poolName - Name of pool to use
-	 * @return - ResourcePool object
-	 * @throws InvalidProperty
-	 * @throws RuntimeFault
-	 * @throws RemoteException
-	 * @throws MalformedURLException
-	 * @throws VSphereException
-	 */
-	private ResourcePool getResourcePoolByName(final String poolName, ManagedEntity rootEntity) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
-		if (rootEntity==null) rootEntity=getServiceInstance().getRootFolder();
+    /**
+     * @param poolName - Name of pool to use
+     * @return - ResourcePool object
+     * @throws InvalidProperty
+     * @throws RuntimeFault
+     * @throws RemoteException
+     * @throws MalformedURLException
+     * @throws VSphereException
+     */
+    private ResourcePool getResourcePoolByName(final String poolName, ManagedEntity rootEntity) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
+        if (rootEntity==null) rootEntity=getServiceInstance().getRootFolder();
 
-		return (ResourcePool) new InventoryNavigator(
-				rootEntity).searchManagedEntity(
-						"ResourcePool", poolName);
-	}
+        return (ResourcePool) new InventoryNavigator(
+                rootEntity).searchManagedEntity(
+                        "ResourcePool", poolName);
+    }
 
-	/**
-	 * @param clusterName - Name of cluster name to find
-	 * @param rootEntity - managed entity to search
-	 * @return - ClusterComputeResource object
-	 * @throws InvalidProperty
-	 * @throws RuntimeFault
-	 * @throws RemoteException
-	 * @throws MalformedURLException 
-	 * @throws VSphereException 
-	 */
-	private ClusterComputeResource getClusterByName(final String clusterName, ManagedEntity rootEntity) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
-		if (rootEntity==null) rootEntity=getServiceInstance().getRootFolder();
+    /**
+     * @param clusterName - Name of cluster name to find
+     * @param rootEntity - managed entity to search
+     * @return - ClusterComputeResource object
+     * @throws InvalidProperty
+     * @throws RuntimeFault
+     * @throws RemoteException
+     * @throws MalformedURLException 
+     * @throws VSphereException 
+     */
+    private ClusterComputeResource getClusterByName(final String clusterName, ManagedEntity rootEntity) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
+        if (rootEntity==null) rootEntity=getServiceInstance().getRootFolder();
 
-		return (ClusterComputeResource) new InventoryNavigator(
-				rootEntity).searchManagedEntity(
-						"ClusterComputeResource", clusterName);
-	}
+        return (ClusterComputeResource) new InventoryNavigator(
+                rootEntity).searchManagedEntity(
+                        "ClusterComputeResource", clusterName);
+    }
 
-	/**
-	 * @param clusterName - Name of cluster name to find
-	 * @return - ClusterComputeResource object
-	 * @throws InvalidProperty
-	 * @throws RuntimeFault
-	 * @throws RemoteException
-	 * @throws MalformedURLException 
-	 * @throws VSphereException 
-	 */
-	private ClusterComputeResource getClusterByName(final String clusterName) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
-		return getClusterByName(clusterName, null);
-	}
+    /**
+     * @param clusterName - Name of cluster name to find
+     * @return - ClusterComputeResource object
+     * @throws InvalidProperty
+     * @throws RuntimeFault
+     * @throws RemoteException
+     * @throws MalformedURLException 
+     * @throws VSphereException 
+     */
+    private ClusterComputeResource getClusterByName(final String clusterName) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
+        return getClusterByName(clusterName, null);
+    }
 
-	/**
-	 * Destroys the VM in vSphere
-	 * @param name - VM object to destroy
-	 * @param failOnNoExist If true and the VM does not exist then a {@link VSphereNotFoundException} will be thrown.
-	 * @throws VSphereException If an error occurred.
-	 */
-	public void destroyVm(String name, boolean failOnNoExist) throws VSphereException{
-		try{
-			VirtualMachine vm = getVmByName(name);
-			if(vm==null){
-				if (failOnNoExist) throw new VSphereNotFoundException("VM", name);
+    /**
+     * Destroys the VM in vSphere
+     * @param name - VM object to destroy
+     * @param failOnNoExist If true and the VM does not exist then a {@link VSphereNotFoundException} will be thrown.
+     * @throws VSphereException If an error occurred.
+     */
+    public void destroyVm(String name, boolean failOnNoExist) throws VSphereException {
+        try {
+            VirtualMachine vm = getVmByName(name);
+            if (vm==null) {
+                if (failOnNoExist) throw new VSphereNotFoundException("VM", name);
 
-				LOGGER.log(Level.FINER, "VM \"" + name + "\" does not exist, or already deleted!");
-				return;
-			}
+                LOGGER.log(Level.FINER, "VM \"" + name + "\" does not exist, or already deleted!");
+                return;
+            }
 
-
-			if(!vm.getConfig().template) {
+            if (!vm.getConfig().template) {
                 powerOffVm(vm, true, false);
             }
 
-			final Task task = vm.destroy_Task();
-			String status = task.waitForTask();
-			if(status.equals(Task.SUCCESS))
-			{
-				LOGGER.log(Level.FINER, "VM \"" + name + "\" was deleted successfully.");
-				return;
-			}
-			throw newVSphereException(task.getTaskInfo(), "Could not delete VM \""+ name +"\"!");
+            final Task task = vm.destroy_Task();
+            String status = task.waitForTask();
+            if (status.equals(Task.SUCCESS)) {
+                LOGGER.log(Level.FINER, "VM \"" + name + "\" was deleted successfully.");
+                return;
+            }
+            throw newVSphereException(task.getTaskInfo(), "Could not delete VM \""+ name +"\"!");
 
-		} catch(RuntimeException | VSphereException e){
-			throw e;
-		}catch(Exception e){
-			throw new VSphereException(e.getMessage(), e);
-		}
-	}
+        } catch(RuntimeException | VSphereException e) {
+            throw e;
+        } catch(Exception e) {
+            throw new VSphereException(e.getMessage(), e);
+        }
+    }
 
     /**
      * Renames a VM Snapshot
@@ -815,10 +806,10 @@ public class VSphere {
      * @param newDescription the new description of the VM's snapshot.
      * @throws VSphereException If an error occurred.
      */
-    public void renameVmSnapshot(String vmName, String oldName, String newName, String newDescription) throws VSphereException{
-        try{
+    public void renameVmSnapshot(String vmName, String oldName, String newName, String newDescription) throws VSphereException {
+        try {
             VirtualMachine vm = getVmByName(vmName);
-            if(vm==null){
+            if (vm==null) {
                 throw new VSphereNotFoundException("VM", vmName);
             }
 
@@ -829,9 +820,9 @@ public class VSphere {
             LOGGER.log(Level.FINER, "VM Snapshot was renamed successfully.");
             return;
 
-        } catch(RuntimeException | VSphereException e){
+        } catch(RuntimeException | VSphereException e) {
             throw e;
-        }catch(Exception e){
+        } catch(Exception e) {
             throw new VSphereException(e.getMessage(), e);
         }
     }
@@ -842,56 +833,55 @@ public class VSphere {
      * @param newName the new name of the vm
      * @throws VSphereException If an error occurred.
      */
-    public void renameVm(String oldName, String newName) throws VSphereException{
-        try{
+    public void renameVm(String oldName, String newName) throws VSphereException {
+        try {
             VirtualMachine vm = getVmByName(oldName);
-            if(vm==null){
+            if (vm==null) {
                 throw new VSphereNotFoundException("VM", oldName);
             }
 
             final Task task = vm.rename_Task(newName);
             final String status = task.waitForTask();
-            if(status.equals(Task.SUCCESS))
-            {
+            if (status.equals(Task.SUCCESS)) {
                 LOGGER.log(Level.FINER, "VM was renamed successfully.");
                 return;
             }
             throw newVSphereException(task.getTaskInfo(), "Could not rename VM \""+ oldName +"\"!");
 
-        } catch(RuntimeException | VSphereException e){
+        } catch(RuntimeException | VSphereException e) {
             throw e;
-        }catch(Exception e){
+        } catch(Exception e) {
             throw new VSphereException(e.getMessage(), e);
         }
     }
 
-	private boolean isSuspended(VirtualMachine vm){
-		return (vm.getRuntime().getPowerState() ==  VirtualMachinePowerState.suspended);
-	}
+    private boolean isSuspended(VirtualMachine vm) {
+        return (vm.getRuntime().getPowerState() ==  VirtualMachinePowerState.suspended);
+    }
 
-	private boolean isPoweredOn(VirtualMachine vm){
-		return (vm.getRuntime().getPowerState() ==  VirtualMachinePowerState.poweredOn);
-	}
+    private boolean isPoweredOn(VirtualMachine vm) {
+        return (vm.getRuntime().getPowerState() ==  VirtualMachinePowerState.poweredOn);
+    }
 
-	private boolean isPoweredOff(VirtualMachine vm){
-		return (vm.getRuntime() != null && vm.getRuntime().getPowerState() ==  VirtualMachinePowerState.poweredOff);
-	}
+    private boolean isPoweredOff(VirtualMachine vm) {
+        return (vm.getRuntime() != null && vm.getRuntime().getPowerState() ==  VirtualMachinePowerState.poweredOff);
+    }
 
     public boolean vmToolIsEnabled(VirtualMachine vm) {
         VirtualMachineToolsStatus status = vm.getGuest().toolsStatus;
         return ((status == VirtualMachineToolsStatus.toolsOk) || (status == VirtualMachineToolsStatus.toolsOld));
     }
 
-	public void powerOffVm(VirtualMachine vm, boolean evenIfSuspended, boolean shutdownGracefully) throws VSphereException{
+    public void powerOffVm(VirtualMachine vm, boolean evenIfSuspended, boolean shutdownGracefully) throws VSphereException {
 
-		if(vm.getConfig().template)
-			throw new VSphereException("VM represents a template!");
+        if (vm.getConfig().template)
+            throw new VSphereException("VM represents a template!");
 
-		if (isPoweredOn(vm) || (evenIfSuspended && isSuspended(vm))) {
+        if (isPoweredOn(vm) || (evenIfSuspended && isSuspended(vm))) {
             boolean doHardShutdown = true;
 
             String status;
-			try {
+            try {
                 if (!isSuspended(vm) && shutdownGracefully && vmToolIsEnabled(vm)) {
                     LOGGER.log(Level.FINER, "Requesting guest shutdown");
                     vm.shutdownGuest();
@@ -917,142 +907,132 @@ public class VSphere {
                     final Task task = vm.powerOffVM_Task();
                     status = task.waitForTask();
 
-                    if(status.equals(Task.SUCCESS)) {
+                    if (status.equals(Task.SUCCESS)) {
                         LOGGER.log(Level.FINER, "VM was powered down successfully.");
                         return;
                     }
                     throw newVSphereException(task.getTaskInfo(), "Machine could not be powered down!");
                 }
-            } catch(RuntimeException | VSphereException e){
+            } catch(RuntimeException | VSphereException e) {
                 throw e;
-			} catch (Exception e) {
-				throw new VSphereException(e);
-			}
-		}
-		else if (isPoweredOff(vm)){
-			LOGGER.log(Level.FINER, "Machine is already off.");
-			return;
-		}
+            } catch (Exception e) {
+                throw new VSphereException(e);
+            }
+        }
+        else if (isPoweredOff(vm)) {
+            LOGGER.log(Level.FINER, "Machine is already off.");
+            return;
+        }
 
-		throw new VSphereException("Machine could not be powered down!");
-	}
+        throw new VSphereException("Machine could not be powered down!");
+    }
 
-	public void suspendVm(VirtualMachine vm) throws VSphereException{
-		if (isPoweredOn(vm)) {
-			try {
-				//TODO is this better?
-				//vm.shutdownGuest()
-				final Task task = vm.suspendVM_Task();
-				final String status = task.waitForTask();
-				if(Task.SUCCESS.equals(status)) {
-					LOGGER.log(Level.FINER, "VM was suspended successfully.");
-					return;
-				}
-				throw newVSphereException(task.getTaskInfo(), "Machine could not be suspended!");
-			} catch(RuntimeException | VSphereException e){
-				throw e;
-			} catch (Exception e) {
-				throw new VSphereException(e);
-			}
-		}
-		else {
-			LOGGER.log(Level.FINER, "Machine not powered on.");
-			return;
-		}
-	}
+    public void suspendVm(VirtualMachine vm) throws VSphereException {
+        if (isPoweredOn(vm)) {
+            try {
+                //TODO is this better?
+                //vm.shutdownGuest()
+                final Task task = vm.suspendVM_Task();
+                final String status = task.waitForTask();
+                if (Task.SUCCESS.equals(status)) {
+                    LOGGER.log(Level.FINER, "VM was suspended successfully.");
+                    return;
+                }
+                throw newVSphereException(task.getTaskInfo(), "Machine could not be suspended!");
+            } catch(RuntimeException | VSphereException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new VSphereException(e);
+            }
+        }
+        else {
+            LOGGER.log(Level.FINER, "Machine not powered on.");
+            return;
+        }
+    }
 
-	/**
-	 * Private helper functions that finds the datanceter a VirtualMachine belongs to
-	 * @param managedEntity - VM object
-	 * @return returns Datacenter object
-	 */
-	private Datacenter getDataCenter(ManagedEntity managedEntity)
-	{
-		if (managedEntity != null) {
-			ManagedEntity parent = managedEntity.getParent();
-			if (parent.getMOR().getType().equals("Datacenter")) {
-				return (Datacenter) parent;
-			} else {
-				return getDataCenter(managedEntity.getParent());
-			}
-		} else {
-			return null;
-		}
-	}
+    /**
+     * Private helper functions that finds the datanceter a VirtualMachine belongs to
+     * @param managedEntity - VM object
+     * @return returns Datacenter object
+     */
+    private Datacenter getDataCenter(ManagedEntity managedEntity) {
+        if (managedEntity != null) {
+            ManagedEntity parent = managedEntity.getParent();
+            if (parent.getMOR().getType().equals("Datacenter")) {
+                return (Datacenter) parent;
+            } else {
+                return getDataCenter(managedEntity.getParent());
+            }
+        } else {
+            return null;
+        }
+    }
 
-	/**
-	 * Find Distributed Virtual Port Group name in the same Datacenter as the VM
-	 * @param virtualMachine - VM object
-	 * @param name - the name of the Port Group
-	 * @return returns DistributedVirtualPortgroup object for the provided vDS PortGroup
-	 * @throws VSphereException If an error occurred.
-	 */
-	public Network getNetworkPortGroupByName(VirtualMachine virtualMachine,
-														String name) throws VSphereException
-	{
-		try {
-			Datacenter datacenter = getDataCenter(virtualMachine);
-			for (Network network : datacenter.getNetworks())
-			{
-				if (network instanceof Network &&
-						(name.isEmpty() || network.getName().contentEquals(name)))
-				{
-					return network;
-				}
-			}
-		} catch (Exception e) {
-			throw new VSphereException(e);
-		}
-		return null;
-	}
+    /**
+     * Find Distributed Virtual Port Group name in the same Datacenter as the VM
+     * @param virtualMachine - VM object
+     * @param name - the name of the Port Group
+     * @return returns DistributedVirtualPortgroup object for the provided vDS PortGroup
+     * @throws VSphereException If an error occurred.
+     */
+    public Network getNetworkPortGroupByName(VirtualMachine virtualMachine,
+            String name) throws VSphereException {
+        try {
+            Datacenter datacenter = getDataCenter(virtualMachine);
+            for (Network network : datacenter.getNetworks()) {
+                if (network instanceof Network &&
+                        (name.isEmpty() || network.getName().contentEquals(name))) {
+                    return network;
+                }
+            }
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
+        return null;
+    }
 
-	/**
-	 * Find Distributed Virtual Port Group name in the same Datacenter as the VM
-	 * @param virtualMachine - VM object
-	 * @param name - the name of the Port Group
-	 * @return returns DistributedVirtualPortgroup object for the provided vDS PortGroup
-	 * @throws VSphereException If an error occurred.
-	 */
-	public DistributedVirtualPortgroup getDistributedVirtualPortGroupByName(VirtualMachine virtualMachine,
-																			 String name) throws VSphereException
-	{
-		try {
-			Datacenter datacenter = getDataCenter(virtualMachine);
-			for (Network network : datacenter.getNetworks())
-			{
-				if (network instanceof DistributedVirtualPortgroup &&
-						(name.isEmpty() || network.getName().contentEquals(name)))
-				{
-					return (DistributedVirtualPortgroup)network;
-				}
-			}
-		} catch (Exception e) {
-			throw new VSphereException(e);
-		}
-		return null;
-	}
+    /**
+     * Find Distributed Virtual Port Group name in the same Datacenter as the VM
+     * @param virtualMachine - VM object
+     * @param name - the name of the Port Group
+     * @return returns DistributedVirtualPortgroup object for the provided vDS PortGroup
+     * @throws VSphereException If an error occurred.
+     */
+    public DistributedVirtualPortgroup getDistributedVirtualPortGroupByName(VirtualMachine virtualMachine,
+            String name) throws VSphereException {
+        try {
+            Datacenter datacenter = getDataCenter(virtualMachine);
+            for (Network network : datacenter.getNetworks()) {
+                if (network instanceof DistributedVirtualPortgroup &&
+                        (name.isEmpty() || network.getName().contentEquals(name))) {
+                    return (DistributedVirtualPortgroup)network;
+                }
+            }
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
+        return null;
+    }
 
-	/**
-	 * Find Distributed Virtual Switch from the provided Distributed Virtual Portgroup
-	 * @param distributedVirtualPortgroup - DistributedVirtualPortgroup object for the provided vDS PortGroup
-	 * @return returns DistributedVirtualSwitch object that represents the vDS Switch
-	 * @throws VSphereException If an error occurred.
-	 */
-	public DistributedVirtualSwitch getDistributedVirtualSwitchByPortGroup(
-			DistributedVirtualPortgroup distributedVirtualPortgroup) throws VSphereException
-	{
-		try
-		{
-			ManagedObjectReference managedObjectReference = new ManagedObjectReference();
-			managedObjectReference.setType("DistributedVirtualSwitch");
-			managedObjectReference.setVal(distributedVirtualPortgroup.getConfig().getDistributedVirtualSwitch().getVal());
-			return new DistributedVirtualSwitch(getServiceInstance().getServerConnection(), managedObjectReference);
-		}
-		catch (Exception e)
-		{
-			throw new VSphereException(e);
-		}
-	}
+    /**
+     * Find Distributed Virtual Switch from the provided Distributed Virtual Portgroup
+     * @param distributedVirtualPortgroup - DistributedVirtualPortgroup object for the provided vDS PortGroup
+     * @return returns DistributedVirtualSwitch object that represents the vDS Switch
+     * @throws VSphereException If an error occurred.
+     */
+    public DistributedVirtualSwitch getDistributedVirtualSwitchByPortGroup(
+            DistributedVirtualPortgroup distributedVirtualPortgroup) throws VSphereException {
+        try {
+            ManagedObjectReference managedObjectReference = new ManagedObjectReference();
+            managedObjectReference.setType("DistributedVirtualSwitch");
+            managedObjectReference.setVal(distributedVirtualPortgroup.getConfig().getDistributedVirtualSwitch().getVal());
+            return new DistributedVirtualSwitch(getServiceInstance().getServerConnection(), managedObjectReference);
+        }
+        catch (Exception e) {
+            throw new VSphereException(e);
+        }
+    }
 
     /**
      * Passes data to a VM's "extra config" object. This data can then be read

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -29,7 +29,6 @@ import javax.annotation.Nonnull;
 
 import org.apache.commons.lang.StringUtils;
 
-import com.vmware.vim25.CustomizationSpec;
 import com.vmware.vim25.CustomizationSpecItem;
 import com.vmware.vim25.GuestInfo;
 import com.vmware.vim25.InvalidProperty;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereLogger.java
@@ -18,21 +18,21 @@ import java.io.PrintStream;
 
 public class VSphereLogger {
 
-	/**
-	 * This is simply a wrapper method to clean up this class.  This method
-	 * checks the verboseOutput flag and writes to the logger as appropriate.
-	 * 
+    /**
+     * This is simply a wrapper method to clean up this class.  This method
+     * checks the verboseOutput flag and writes to the logger as appropriate.
+     * 
      * @param logger - logger that should receive the information
      * @param str - The text to be logged.
-	 */
-	public static void vsLogger(PrintStream logger, String str){
-		if(logger!=null){
-			logger.println("["+Messages.VSphereLogger_title()+"] "+str);
-		}
-	}
+     */
+    public static void vsLogger(PrintStream logger, String str) {
+        if (logger!=null) {
+            logger.println("["+Messages.VSphereLogger_title()+"] "+str);
+        }
+    }
 
-    public static void vsLogger(PrintStream logger, Exception e){
-        if(logger == null) {
+    public static void vsLogger(PrintStream logger, Exception e) {
+        if (logger == null) {
             return;
         }
 


### PR DESCRIPTION
Some Java files use a mix of tabs and spaces, which makes it almost impossible for contributors to "fit in" with the existing code style (as there isn't one).  This PR goes some way to making these self-consistent by turning tabs to spaces in Java files that used both.  Files which used tabs throughout have not been modified.
Some Java files had unused import statements which caused warnings in my IDE.
One file had an unused local variable.