### PR TITLE
Subset of changes from PR #67

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.6</version>
+        <version>2.22</version>
     </parent>
 
     <artifactId>vsphere-cloud</artifactId>
@@ -37,27 +37,27 @@
         <connection>scm:git:https://github.com/jenkinsci/vsphere-cloud-plugin.git</connection>
         <developerConnection>scm:git:https://git@github.com/jenkinsci/vsphere-cloud-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/vsphere-cloud-plugin</url>
-      <tag>HEAD</tag>
-  </scm>    
+        <tag>HEAD</tag>
+    </scm>    
   
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
- <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <name>Jenkins Repository</name>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <name>Jenkins Repository</name>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
 
-  <pluginRepositories>
-     <pluginRepository>
-        <id>repo.jenkins-ci.org</id>
-        <url>http://repo.jenkins-ci.org/public/</url>
-     </pluginRepository>
-  </pluginRepositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
     
     <dependencies>
         <dependency>
@@ -119,4 +119,3 @@
         </plugins>
     </build>
 </project>
-

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -64,7 +64,7 @@ public class vSphereCloud extends Cloud {
     private transient ConcurrentHashMap<String, String> currentOnline;
     private transient CloudProvisioningState templateState;
 
-    private static java.util.logging.Logger VSLOG = java.util.logging.Logger.getLogger("vsphere-cloud");
+    private static final java.util.logging.Logger VSLOG = java.util.logging.Logger.getLogger("vsphere-cloud");
 
     private static void InternalLog(Slave slave, SlaveComputer slaveComputer, TaskListener listener, Throwable ex, Level logLevel, String format, Object... args) {
         if (!VSLOG.isLoggable(logLevel) && listener == null)
@@ -496,6 +496,7 @@ public class vSphereCloud extends Cloud {
             final vSphereCloudSlaveTemplate template = whatWeShouldSpinUp.getTemplate();
             final int numberOfExecutors = template.getNumberOfExecutors();
             final Callable<Node> provisionNodeCallable = new Callable<Node>() {
+                @Override
                 public Node call() throws Exception {
                     try {
                         final Node newNode = provisionNewNode(whatWeShouldSpinUp, nodeName);

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudRunListener.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Extension
 public final class vSphereCloudRunListener extends RunListener<Run> {
     
-    private List<Run> LimitedRuns = new ArrayList<Run>();
+    private final List<Run> LimitedRuns = new ArrayList<Run>();
 
     public vSphereCloudRunListener() {
     }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
@@ -57,6 +57,7 @@ public abstract class VSphereBuildStep implements Describable<VSphereBuildStep>,
 
 	public abstract void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException;
 
+	@Override
 	public VSphereBuildStepDescriptor getDescriptor() {
 		return (VSphereBuildStepDescriptor) Jenkins.getInstance().getDescriptor(getClass());
 	}

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ConvertToVm.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ConvertToVm.java
@@ -70,6 +70,7 @@ public class ConvertToVm extends VSphereBuildStep {
         }
     }
 
+    @Override
     public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)  {
         boolean retVal = false;
         try {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -309,19 +309,23 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
      */
     private static class VSphereEnvAction implements EnvironmentContributingAction {
         // Decided not to record this data in build.xml, so marked transient:
-        private transient Map<String,String> data = new HashMap<String,String>();
+        private final transient Map<String,String> data = new HashMap<String,String>();
 
         private void add(String key, String val) {
             if (data==null) return;
             data.put(key, val);
         }
 
+        @Override
         public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
             if (data!=null) env.putAll(data);
         }
 
+        @Override
         public String getIconFileName() { return null; }
+        @Override
         public String getDisplayName() { return null; }
+        @Override
         public String getUrlName() { return null; }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo.java
@@ -40,7 +40,7 @@ public class ExposeGuestInfo extends VSphereBuildStep implements SimpleBuildStep
     private final Boolean waitForIp4;
     private String resolvedEnvVariablePrefix = null;
     private String IP;
-    private Map <String, String> envVars = new HashMap<>();
+    private final Map<String, String> envVars = new HashMap<>();
 
     @DataBoundConstructor
     public ExposeGuestInfo(final String vm, final String envVariablePrefix, Boolean waitForIp4) throws VSphereException {
@@ -259,12 +259,16 @@ public class ExposeGuestInfo extends VSphereBuildStep implements SimpleBuildStep
             data.put(key, val);
         }
 
+        @Override
         public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
             if (data!=null) env.putAll(data);
         }
 
+        @Override
         public String getIconFileName() { return null; }
+        @Override
         public String getDisplayName() { return null; }
+        @Override
         public String getUrlName() { return null; }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/PowerOn.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/PowerOn.java
@@ -185,19 +185,23 @@ public class PowerOn extends VSphereBuildStep {
 	 */
 	private static class VSphereEnvAction implements EnvironmentContributingAction {
 		// Decided not to record this data in build.xml, so marked transient:
-		private transient Map<String,String> data = new HashMap<String,String>();
+		private final transient Map<String,String> data = new HashMap<String,String>();
 
 		private void add(String key, String val) {
 			if (data==null) return;
 			data.put(key, val);
 		}
 
+		@Override
 		public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
 			if (data!=null) env.putAll(data);
 		}
 
+		@Override
 		public String getIconFileName() { return null; }
+		@Override
 		public String getDisplayName() { return null; }
+		@Override
 		public String getUrlName() { return null; }
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Reconfigure.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Reconfigure.java
@@ -20,6 +20,7 @@ import hudson.*;
 import hudson.model.*;
 import hudson.tasks.BuildStepMonitor;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.vsphere.VSphereBuildStep;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
@@ -127,8 +128,9 @@ public class Reconfigure extends VSphereBuildStep implements SimpleBuildStep{
 		return true;
 	}
 
+	@Override
     public ReconfigureDescriptor getDescriptor() {
-        return (ReconfigureDescriptor) Hudson.getInstance().getDescriptor(getClass());
+        return (ReconfigureDescriptor) Jenkins.getInstance().getDescriptor(getClass());
     }
 
 	@Extension

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/RenameSnapshot.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/RenameSnapshot.java
@@ -78,6 +78,7 @@ public class RenameSnapshot extends VSphereBuildStep implements SimpleBuildStep 
 		return false;
 	}
 
+	@Override
 	public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)  {
 		boolean retVal = false;
 		try {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/SuspendVm.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/SuspendVm.java
@@ -61,6 +61,7 @@ public class SuspendVm extends VSphereBuildStep implements SimpleBuildStep {
 		return false;
 	}
 
+	@Override
 	public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)  {
 		boolean retVal = false;
 		try {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/TakeSnapshot.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/TakeSnapshot.java
@@ -79,6 +79,7 @@ public class TakeSnapshot extends VSphereBuildStep implements SimpleBuildStep {
 		return false;
 	}
 
+	@Override
 	public boolean perform(final AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener)  {
 		boolean retVal = false;
 		try {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter.java
@@ -43,6 +43,7 @@ public class CloudSelectorParameter extends SimpleParameterDefinition {
         return checkValue(value);
     }
 
+    @Override
     public StringParameterValue createValue(String value) {
         return checkValue(new StringParameterValue(getName(), value, getDescription()));
     }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -13,7 +13,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 import org.jenkinsci.plugins.vSphereCloudSlaveTemplate;
-import org.jenkinsci.plugins.vsphere.tools.CloudProvisioningRecord;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
https://github.com/jenkinsci/vsphere-cloud-plugin/pull/67 fixes a number of findbugs warnings but then failed to build and failed to merge.
This change includes a number of the "safer" changes from that pull request:
 - Remove unnecessary imports.
 - Add missing `@Override` annotations.
 - Add `final` keyword when appropriate.
 - Use `jenkins.model.Jenkins` instead of `Hudson`
 - Update `org.jenkins-ci.plugins`/`plugin` version from 2.6 to 2.22