### PR TITLE
Remainder of PR #67

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.22</version>
+        <version>2.29</version>
     </parent>
 
     <artifactId>vsphere-cloud</artifactId>
@@ -32,14 +32,14 @@
             <comments>A business-friendly OSS license</comments>
         </license>
      </licenses>
- 
+
     <scm>
         <connection>scm:git:https://github.com/jenkinsci/vsphere-cloud-plugin.git</connection>
         <developerConnection>scm:git:https://git@github.com/jenkinsci/vsphere-cloud-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/vsphere-cloud-plugin</url>
         <tag>HEAD</tag>
-    </scm>    
-  
+    </scm>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -58,7 +58,7 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.kohsuke.stapler</groupId>
@@ -106,7 +106,7 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
-                    <disabledTestInjection>true</disabledTestInjection>
+                    <disabledTestInjection>false</disabledTestInjection>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.jenkinsci.plugins;
 
 import hudson.Util;
@@ -66,20 +62,30 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
         this.waitForVMTools = waitForVMTools;
         this.snapName = snapName;
         this.launchDelay = Util.tryParseNumber(launchDelay, 60).intValue();
-        if ("Shutdown".equals(idleOption)) {
-            idleAction = MACHINE_ACTION.SHUTDOWN;
-        } else if ("Shutdown and Revert".equals(idleOption)) {
-            idleAction = MACHINE_ACTION.REVERT;
-        } else if ("Revert and Restart".equals(idleOption)) {
-            idleAction = MACHINE_ACTION.REVERT_AND_RESTART;
-        } else if ("Revert and Reset".equals(idleOption)) {
-            idleAction = MACHINE_ACTION.REVERT_AND_RESET;
-        } else if ("Reset".equals(idleOption)) {
-            idleAction = MACHINE_ACTION.RESET;
-        } else if ("Suspend".equals(idleOption)) {
-            idleAction = MACHINE_ACTION.SUSPEND;
-        } else {
+        if (null == idleOption) {
             idleAction = MACHINE_ACTION.NOTHING;
+        } else switch (idleOption) {
+            case "Shutdown":
+                idleAction = MACHINE_ACTION.SHUTDOWN;
+                break;
+            case "Shutdown and Revert":
+                idleAction = MACHINE_ACTION.REVERT;
+                break;
+            case "Revert and Restart":
+                idleAction = MACHINE_ACTION.REVERT_AND_RESTART;
+                break;
+            case "Revert and Reset":
+                idleAction = MACHINE_ACTION.REVERT_AND_RESET;
+                break;
+            case "Reset":
+                idleAction = MACHINE_ACTION.RESET;
+                break;
+            case "Suspend":
+                idleAction = MACHINE_ACTION.SUSPEND;
+                break;
+            default:
+                idleAction = MACHINE_ACTION.NOTHING;
+                break;
         }
         this.LimitedTestRunCount = Util.tryParseNumber(LimitedTestRunCount, 0).intValue();
     }
@@ -336,19 +342,25 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                         case NOTHING:
                             break;
                     }
-                    if (localIdle == MACHINE_ACTION.REVERT) {
-                        revertVM(vm, vsC, slaveComputer, taskListener);
-                    } else if (localIdle == MACHINE_ACTION.REVERT_AND_RESTART) {
-                        revertVM(vm, vsC, slaveComputer, taskListener);
-                        if (power == VirtualMachinePowerState.poweredOn) {
-                             // Some time is needed for the VMWare Tools to reactivate
-                            Thread.sleep(60000);
-                            shutdownVM(vm, slaveComputer, taskListener);
-                        }
-                        powerOnVM(vm, slaveComputer, taskListener);
-                    } else if (localIdle == MACHINE_ACTION.REVERT_AND_RESET) {
-                        revertVM(vm, vsC, slaveComputer, taskListener);
-                        resetVM(vm, slaveComputer, taskListener);
+                    switch (localIdle) {
+                        case REVERT:
+                            revertVM(vm, vsC, slaveComputer, taskListener);
+                            break;
+                        case REVERT_AND_RESTART:
+                            revertVM(vm, vsC, slaveComputer, taskListener);
+                            if (power == VirtualMachinePowerState.poweredOn) {
+                                // Some time is needed for the VMWare Tools to reactivate
+                                Thread.sleep(60000);
+                                shutdownVM(vm, slaveComputer, taskListener);
+                            }
+                            powerOnVM(vm, slaveComputer, taskListener);
+                            break;
+                        case REVERT_AND_RESET:
+                            revertVM(vm, vsC, slaveComputer, taskListener);
+                            resetVM(vm, slaveComputer, taskListener);
+                            break;
+                        default:
+                            break;
                     }
                 } else {
                         // VM is already powered down.

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureCpu.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureCpu.java
@@ -15,7 +15,6 @@
 package org.jenkinsci.plugins.vsphere.builders;
 
 import hudson.*;
-import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Run;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningRecord.java
@@ -123,7 +123,7 @@ public final class CloudProvisioningRecord {
 
     private double calcFullness() {
         final int maxToProvision = calcMaxToProvision();
-        return ((double) calcCurrentCommitment()) / (double) maxToProvision;
+        return calcCurrentCommitment() / (double) maxToProvision;
     }
 
     boolean hasCapacityForMore() {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config-inner.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config-inner.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <table width="100%">
         <st:include page="config.jelly" class="${descriptor.clazz}"/>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Name of this Cloud}" field="vsDescription">
         <f:textbox/>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudLauncher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudLauncher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <j:if test="${it.launchSupported and it.offline and !it.temporarilyOffline}">
         <j:choose>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/configure-entries.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/configure-entries.jelly
@@ -1,6 +1,7 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-             
+
     <f:entry title="${%vSphere Cloud Instance}" field="vsDescription">
         <select class="setting-input" name="vsDescription" value="${it.vsDescription}" >
             <option>Select a vSphere Cloud instance...</option>
@@ -18,7 +19,7 @@
     <f:entry title="${%Snapshot Name}" field="snapName">
         <f:textbox />
     </f:entry>
-    
+
     <f:validateButton title="${%Test VM Connection}" progress="${%Testing...}" method="testConnection" with="vsDescription,vmName,snapName"/>
 
     <f:entry title="${%Description}" help="/help/system-config/master-slave/description.html">
@@ -48,7 +49,7 @@
        description="${%Wait for VMTools in the VM to start up.}" >
         <f:checkbox />
     </f:entry>
-    
+
     <f:entry title="${%Delay between launch and boot complete}" field="launchDelay"
     description="${%How many seconds between the VM being brought back to life before Jenkins can connect and bring it online as a slave.}" >
         <f:textbox default="60" />

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <table width="100%">
         <f:entry title="${%Clone Name Prefix}" field="cloneNamePrefix">

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Idle Timeout}" field="idleMinutes">
         <f:number default="2"/>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer/config.jelly
@@ -17,7 +17,7 @@ limitations under the License.
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Server}" field="serverName">
-		<f:select />
+        <f:select />
     </f:entry>
     <f:entry>
         <f:dropdownDescriptorSelector title="${%vSphere Action}" field="buildStep" descriptors="${descriptor.buildSteps}" />

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Idle Timeout}" field="idleMinutes">
         <f:number default="5"/>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereGuestInfoProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereGuestInfoProperty/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <table width="100%">
         <f:entry title="${%Property Name}" field="name">

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%SourceName}" field="sourceName">

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ConvertToTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ConvertToTemplate/config.jelly
@@ -13,15 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:entry title="${%Force}" field="force">
-	      <f:checkbox  />
-    </f:entry>
-    
-    <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,description"/>    
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="${%Force}" field="force">
+    <f:checkbox  />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,description"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ConvertToVm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ConvertToVm/config.jelly
@@ -13,19 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Template}" field="template">
-      <f:textbox  />
-    </f:entry>
-		
-	<f:entry title="${%Cluster}" field="cluster">
-      <f:textbox  />
-    </f:entry>
+  <f:entry title="${%Template}" field="template">
+    <f:textbox />
+  </f:entry>
 
-	<f:entry title="${%Resource Pool}" field="resourcePool">
-      <f:textbox  />
-    </f:entry>
+  <f:entry title="${%Cluster}" field="cluster">
+    <f:textbox />
+  </f:entry>
 
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,template,resourcePool,cluster"/>
+  <f:entry title="${%Resource Pool}" field="resourcePool">
+    <f:textbox />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,template,resourcePool,cluster"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Delete/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Delete/config.jelly
@@ -13,15 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-    
-   	<f:entry title="${%Fail on null?}" field="failOnNoExist">
-  	  <f:checkbox  />
-  	</f:entry>
-    
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Fail on null?}" field="failOnNoExist">
+    <f:checkbox />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/DeleteSnapshot/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/DeleteSnapshot/config.jelly
@@ -13,23 +13,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:entry title="${%Snapshot Name}" field="snapshotName">
-	  <f:textbox />
-	</f:entry>
-	
-	<f:entry title="${%Consolidate disks?}" field="consolidate">
-	  <f:checkbox />
-	</f:entry>
-	
-	<f:entry title="${%Fail on null?}" field="failOnNoExist">
-  	  <f:checkbox  />
-  	</f:entry>
-	
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,snapshotName"/>
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Snapshot Name}" field="snapshotName">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Consolidate disks?}" field="consolidate">
+    <f:checkbox />
+  </f:entry>
+
+  <f:entry title="${%Fail on null?}" field="failOnNoExist">
+    <f:checkbox />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,snapshotName"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Template}" field="template">

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/config.jelly
@@ -13,19 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:entry title="${%EnvVariablePrefix}" field="envVariablePrefix">
-	  <f:textbox default="VSPHERE" />
-	</f:entry>
+<?jelly escape-by-default='true'?>
 
-	<f:entry title="${%wait For Ip 4?}" field="waitForIp4">
-		<f:checkbox checked="true"/>
-	</f:entry>
-	
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%EnvVariablePrefix}" field="envVariablePrefix">
+    <f:textbox default="VSPHERE"/>
+  </f:entry>
+
+  <f:entry title="${%wait For Ip 4?}" field="waitForIp4">
+    <f:checkbox checked="true"/>
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/PowerOff/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/PowerOff/config.jelly
@@ -13,21 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:entry title="${%If suspended?}" field="evenIfSuspended">
-	    <f:checkbox  />
-	</f:entry>
-	<f:entry title="${%Shutdown gracefully?}" field="shutdownGracefully">
-	    <f:checkbox  />
-	</f:entry>
-	<f:entry title="${%ignore If Not Exists?}" field="ignoreIfNotExists">
-	    <f:checkbox  />
-	</f:entry>
+<?jelly escape-by-default='true'?>
 
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%If suspended?}" field="evenIfSuspended">
+    <f:checkbox />
+  </f:entry>
+  <f:entry title="${%Shutdown gracefully?}" field="shutdownGracefully">
+    <f:checkbox />
+  </f:entry>
+  <f:entry title="${%ignore If Not Exists?}" field="ignoreIfNotExists">
+    <f:checkbox />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/PowerOn/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/PowerOn/config.jelly
@@ -13,15 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:entry title="${%Timeout}" field="timeoutInSeconds">
-	  <f:textbox default="180" />
-	</f:entry>
-	
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Timeout}" field="timeoutInSeconds">
+    <f:textbox default="180" />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Reconfigure/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Reconfigure/config.jelly
@@ -13,9 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
+    <f:entry title="${%VM}" field="vm">
       <f:textbox  />
     </f:entry>
     <f:entry title="${%Reconfigure Hardware}">
@@ -53,5 +54,5 @@ limitations under the License.
 
     </f:entry>
 
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
+    <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Rename/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Rename/config.jelly
@@ -13,15 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Old VM Name}" field="oldName">
-      <f:textbox  />
-    </f:entry>
+<?jelly escape-by-default='true'?>
 
-    <f:entry title="${%New VM Name}" field="newName">
-        <f:textbox  />
-    </f:entry>
-    
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,oldName,newName"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Old VM Name}" field="oldName">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%New VM Name}" field="newName">
+    <f:textbox />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,oldName,newName"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RenameSnapshot/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RenameSnapshot/config.jelly
@@ -13,14 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%VM Name}" field="vm">
         <f:textbox  />
     </f:entry>
 
-	<f:entry title="${%Old Snapshot Name}" field="oldName">
-      <f:textbox  />
+    <f:entry title="${%Old Snapshot Name}" field="oldName">
+        <f:textbox  />
     </f:entry>
 
     <f:entry title="${%New Snapshot Name}" field="newName">
@@ -30,6 +31,6 @@ limitations under the License.
     <f:entry title="${%New Snapshot Description}" field="newDescription">
         <f:textarea />
     </f:entry>
-    
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,oldName,newName"/>
+
+    <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,oldName,newName"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot/config.jelly
@@ -13,15 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:entry title="${%Snapshot Name}" field="snapshotName">
-	  <f:textbox />
-	</f:entry>
-	
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,snapshotName"/>
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Snapshot Name}" field="snapshotName">
+    <f:textbox />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,snapshotName"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/SuspendVm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/SuspendVm/config.jelly
@@ -13,11 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/TakeSnapshot/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/TakeSnapshot/config.jelly
@@ -13,23 +13,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
- 
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%VM}" field="vm">
-      <f:textbox  />
-    </f:entry>
-	
-	<f:entry title="${%Snapshot Name}" field="snapshotName">
-	  <f:textbox />
-	</f:entry>
-	
-	<f:entry title="${%Description}" field="description">
-	  <f:textbox />
-	</f:entry>
-	
-	<f:entry title="${%Include Memory?}" field="includeMemory">
-      <f:checkbox  />
-    </f:entry>
-	
-	<f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,snapshotName"/>
+  <f:entry title="${%VM}" field="vm">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="${%Snapshot Name}" field="snapshotName">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Description}" field="description">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Include Memory?}" field="includeMemory">
+    <f:checkbox  />
+  </f:entry>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,snapshotName"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/config.jelly
@@ -13,5 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" />

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter/index.jelly
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="VSPHERE_CLOUD_NAME">
@@ -26,4 +27,3 @@ limitations under the License.
         </div>
     </f:entry>
 </j:jelly>
-

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/configure-entries.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/configure-entries.jelly
@@ -1,6 +1,7 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-             
+
     <f:entry title="${%vSphere Cloud Instance}" field="vsDescription">
         <select class="setting-input" name="vsDescription" value="${it.vsDescription}" >
             <option>Select a vSphere Cloud instance...</option>
@@ -18,7 +19,7 @@
     <f:entry title="${%Snapshot Name}" field="snapName">
         <f:textbox />
     </f:entry>
-    
+
     <f:validateButton title="${%Test VM Connection}" progress="${%Testing...}" method="testConnection" with="vsDescription,vmName,snapName"/>
 
     <f:entry title="${%Description}" help="/help/system-config/master-slave/description.html">
@@ -48,7 +49,7 @@
        description="${%Wait for VMTools in the VM to start up.}" >
         <f:checkbox />
     </f:entry>
-    
+
     <f:entry title="${%Delay between launch and boot complete}" field="launchDelay"
     description="${%How many seconds between the VM being brought back to life before Jenkins can connect and bring it online as a slave.}" >
         <f:textbox default="60" />

--- a/src/main/resources/org/jenkinsci/plugins/workflow/vSphereStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/vSphereStep/config.jelly
@@ -2,7 +2,7 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Server}" field="serverName">
-		<f:select />
+        <f:select />
     </f:entry>
     <f:entry>
         <f:dropdownDescriptorSelector title="${%vSphere Action}" field="buildStep" descriptors="${descriptor.buildSteps}" />

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -323,8 +323,8 @@ public class CloudProvisioningAlgorithmTest {
     private static String toHexString(byte[] bytes) {
         final StringBuilder s = new StringBuilder("0x");
         for (final byte b : bytes) {
-            final int highDigit = (((int) b) >> 8) & 15;
-            final int lowDigit = ((int) b) & 15;
+            final int highDigit = (b >> 8) & 15;
+            final int lowDigit = b & 15;
             s.append(Integer.toString(highDigit, 16));
             s.append(Integer.toString(lowDigit, 16));
         }


### PR DESCRIPTION
Add the line <?jelly escape-by-default='true'?> where it's absent in jelly files.
Some whitespace changes where we previously has inconsistency.
Removed unnecessary cast.
Removed unnecessary import.
Refactored excessively long if/elseif...else clauses as a switch.
Change version of org.jenkins-ci.plugins/plugin from 2.22 to 2.29, which is the last version that works with a Java7 JDK, and brings us almost to the 2.30 specified in PR #67.