### PR TITLE
pom.xml scm connection changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
      </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/jenkinsci/vsphere-cloud-plugin.git</connection>
-        <developerConnection>scm:git:https://git@github.com/jenkinsci/vsphere-cloud-plugin.git</developerConnection>
+        <connection>scm:git:git://github.com/jenkinsci/vsphere-cloud-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/vsphere-cloud-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/vsphere-cloud-plugin</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
connection now specifies git protocol (as used by most plugins) instead of https.
developerConnection now specifies ssh protocol (as used by most plugins) instead of https.
url is unchanged (still https, just like other plugins).
Hopefully this will allow the release process to work without error...