### PR TITLE
Add Reconnect and Revert Idle Action

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -46,6 +46,7 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
         REVERT_AND_RESTART,
         SUSPEND,
         RESET,
+        RECONNECT_AND_REVERT,
         NOTHING
     }
 
@@ -79,6 +80,9 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                 break;
             case "Reset":
                 idleAction = MACHINE_ACTION.RESET;
+                break;
+            case "Reconnect and Revert":
+                idleAction = MACHINE_ACTION.RECONNECT_AND_REVERT;
                 break;
             case "Suspend":
                 idleAction = MACHINE_ACTION.SUSPEND;
@@ -305,6 +309,7 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
 
         vsSlave.slaveIsDisconnecting = Boolean.TRUE;
         VSphere v = null;
+        boolean reconnect = false;
         try {
             vSphereCloud.Log(slaveComputer, taskListener, "Running disconnect procedure...");
             super.afterDisconnect(slaveComputer, taskListener);
@@ -339,7 +344,7 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                         case RESET:
                             resetVM(vm, slaveComputer, taskListener);
                             break;
-                        case NOTHING:
+                        default:
                             break;
                     }
                     switch (localIdle) {
@@ -359,7 +364,10 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                             revertVM(vm, vsC, slaveComputer, taskListener);
                             resetVM(vm, slaveComputer, taskListener);
                             break;
-                        default:
+                        case RECONNECT_AND_REVERT:
+                            reconnect = true;
+                            break;
+                        case NOTHING:
                             break;
                     }
                 } else {
@@ -377,6 +385,10 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
             }
             vsSlave.slaveIsDisconnecting = Boolean.FALSE;
             vsSlave.slaveIsStarting = Boolean.FALSE;
+
+            if (reconnect) {
+                slaveComputer.connect(false);
+            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudProvisionedSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudProvisionedSlave.java
@@ -148,6 +148,7 @@ public class vSphereCloudProvisionedSlave extends vSphereCloudSlave {
             options.add("Revert and Reset");
             options.add("Suspend");
             options.add("Reset");
+            options.add("Reconnect and Revert");
             options.add("Nothing");
             return options;
         }

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
@@ -402,6 +402,7 @@ public class vSphereCloudSlave extends AbstractCloudSlave {
             options.add("Revert and Reset");
             options.add("Suspend");
             options.add("Reset");
+            options.add("Reconnect and Revert");
             options.add("Nothing");
             return options;
         }

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-idleOption.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-idleOption.html
@@ -6,6 +6,7 @@
         <li><b>Revert and Reset</b>: Same behavior as <b>Revert</b>, followed by a reset.</li>
         <li><b>Suspend</b>: Suspends the virtual machine.</li>
         <li><b>Reset</b>: The VM is reset.</li>
+        <li><b>Reconnect and Revert</b>: The VM is reconnected to Jenkins. If a snapshot name is specified, the VM will be reverted to it when starting up.</li>
         <li><b>Nothing</b>: Nothing is done to the VM; it is left untouched.</li>
     </ul>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-idleOption.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-idleOption.html
@@ -6,6 +6,7 @@
         <li><b>Revert and Reset</b>: Same behavior as <b>Revert</b>, followed by a reset.</li>
         <li><b>Suspend</b>: Suspends the virtual machine.</li>
         <li><b>Reset</b>: The VM is reset.</li>
+        <li><b>Reconnect and Revert</b>: The VM is reconnected to Jenkins. If a snapshot name is specified, the VM will be reverted to it when starting up.</li>
         <li><b>Nothing</b>: Nothing is done to the VM; it is left untouched.</li>
     </ul>
 </div>


### PR DESCRIPTION
- Added idle action to vSphereCloudSlave and
vSphereCloudProvisionedSlave for Reconnect and Revert.
- When selected, the VM will reconnect it's computer
to Jenkins when it's disconnected. When a snapshot
is specified, it will be reverted to at startup
(default functionality in the plugin).