### PR TITLE
[JENKINS-47821] Prevent run-once slave from accepting more jobs.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -446,11 +446,24 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                     sshLauncher.getRetryWaitTime());
             return launcherWithIPAddress;
         }
-        throw new IllegalStateException("Unsupported launcher in template configuration");
+        throw new IllegalStateException("Unsupported launcher (" + launcher + ") in template configuration");
     }
 
     private RetentionStrategy<?> determineRetention() {
-        return retentionStrategy;
+        if (retentionStrategy instanceof RunOnceCloudRetentionStrategy) {
+            final RunOnceCloudRetentionStrategy templateStrategy = (RunOnceCloudRetentionStrategy) retentionStrategy;
+            final RunOnceCloudRetentionStrategy cloneStrategy = new RunOnceCloudRetentionStrategy(
+                    templateStrategy.getIdleMinutes());
+            return cloneStrategy;
+        }
+        if (retentionStrategy instanceof VSphereCloudRetentionStrategy) {
+            final VSphereCloudRetentionStrategy templateStrategy = (VSphereCloudRetentionStrategy) retentionStrategy;
+            final VSphereCloudRetentionStrategy cloneStrategy = new VSphereCloudRetentionStrategy(
+                    templateStrategy.getIdleMinutes());
+            return cloneStrategy;
+        }
+        throw new IllegalStateException(
+                "Unsupported retentionStrategy (" + retentionStrategy + ") in template configuration");
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereOfflineCause.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereOfflineCause.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins.vsphere;
+
+import org.jvnet.localizer.Localizable;
+
+import hudson.slaves.OfflineCause.SimpleOfflineCause;
+
+/**
+ * Offline because the plugin set it offline rather than anyone else.
+ */
+public class VSphereOfflineCause extends SimpleOfflineCause {
+    public VSphereOfflineCause(Localizable description) {
+        super(description);
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/Messages.properties
@@ -1,0 +1,5 @@
+vSphereCloudSlave.OfflineReason.ShuttingDown=Shutting down VSphere Cloud Slave
+vSphereCloudSlave.BlockageReason.NoFlyweightTasks=Don't run FlyweightTasks on vSphere nodes as they can be terminated.
+vSphereCloudSlave.LimitedBuild.TemporaryOffline=Marking the slave as offline due to reaching limited build threshold.
+vSphereCloudSlave.LimitedBuild.Disconnect=Disconnecting the slave as offline due to reaching limited build threshold.
+vSphereCloudSlave.LimitedBuild.TemporarilyOnline=Marking the slave as online after completing post-disconnect actions.

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/Messages.properties
@@ -1,0 +1,1 @@
+runOnceCloudRetentionStrategy.OfflineReason.BuildHasRun=VSphere Cloud Slave configured was to run one build only


### PR DESCRIPTION
vSphereCloudSlaveTemplate
 - now provides each cloud slave it creates with its own RetentionStrategy instance, being a copy of the template's rather than being the same instance.  This allows us to simplify RunOnceCloudRetentionStrategy's implementation as it's no longer shared.

RunOnceCloudRetentionStrategy
 - can no longer be shared between slaves. It now only holds state information about one slave. See also: vSphereCloudSlaveTemplate changes.
 - now overrides isAcceptingTasks to prevent further activity instead of simply setting c.setAcceptingTasks(false).
 - now triggers node termination in-line instead of spawning a new thread for it.  We can do this without slowing Jenkins down because our nodes ask vSphere to delete their VMs in a separate thread.  Hopefully
this should fix the re-use bug.
 - offline reasons now given as a VSphereOfflineCause that can be localized.  See also: vSphereCloudLauncher changes.

vSphereCloudSlave
 - flyweight-task refusal message can now be localized.
 - offline reasons now given as a VSphereOfflineCause that can be localized.  See also: vSphereCloudLauncher changes.

vSphereCloudLauncher
 - no longer uses the special text "vSphere Plugin" in the offline reason to recognise our own offline reasons.  Our code uses now VSphereOfflineCause and so we can now use instanceof to detect these
instead of String.contains.