### PR TITLE
Don't force the use of underscore to separate slave prefix from number.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithm.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithm.java
@@ -70,7 +70,7 @@ public final class CloudProvisioningAlgorithm {
         final int maxAttempts = hasCap ? (templateInstanceCap) : 100;
         for (int attempt = 0; attempt < maxAttempts; attempt++) {
             final String suffix = hasCap ? calcSequentialSuffix(attempt) : calcRandomSuffix(attempt);
-            final String nodeName = cloneNamePrefix + "_" + suffix;
+            final String nodeName = cloneNamePrefix + suffix;
             if (!existingNames.contains(nodeName)) {
                 return nodeName;
             }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -200,8 +200,8 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(2, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String expected1 = prefix + "_1";
-        final String expected2 = prefix + "_2";
+        final String expected1 = prefix + "1";
+        final String expected2 = prefix + "2";
 
         // When
         final String actual1 = CloudProvisioningAlgorithm.findUnusedName(record);
@@ -219,10 +219,10 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(3, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String expected1 = prefix + "_1";
-        final String unwanted = prefix + "_2";
+        final String expected1 = prefix + "1";
+        final String unwanted = prefix + "2";
         record.setCurrentlyUnwanted(unwanted, false);
-        final String expected2 = prefix + "_3";
+        final String expected2 = prefix + "3";
 
         // When
         final String actual1 = CloudProvisioningAlgorithm.findUnusedName(record);
@@ -240,9 +240,9 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(3, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String unwanted = prefix + "_1";
-        final String active = prefix + "_2";
-        final String planned = prefix + "_3";
+        final String unwanted = prefix + "1";
+        final String active = prefix + "2";
+        final String planned = prefix + "3";
         record.setCurrentlyUnwanted(unwanted, false);
         record.addCurrentlyActive(active);
         record.addCurrentlyPlanned(planned);
@@ -264,7 +264,7 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(2, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String expected = prefix + "_1";
+        final String expected = prefix + "1";
 
         // When
         final String actual1 = CloudProvisioningAlgorithm.findUnusedName(record);
@@ -296,7 +296,7 @@ public class CloudProvisioningAlgorithmTest {
         // Then
         final List<String> uniques = new ArrayList<String>(new LinkedHashSet<String>(actuals));
         assertThat(actuals, equalTo(uniques));
-        assertThat(actuals, everyItem(startsWith(prefix + "_")));
+        assertThat(actuals, everyItem(startsWith(prefix)));
     }
 
     private CloudProvisioningRecord createInstance(int capacity, int provisioned, int planned) {


### PR DESCRIPTION
* Underscores complicate things when you want to create DNS records for
  the ephemeral slaves. Underscores are not valid characters for DNS :(
* The user can always add the underscore back in their config.

This should be documented as a breaking functional change but I don't
really see that people would be designing tons of functionality around
this underscore. As a result, there is no migration from pre- to post-
removal versions of the plugin.