### PR TITLE
Stop hard-coding underscore in clone names

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -355,7 +355,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         // Earlier versions of the code may have stored configuration in a
         // different way but in the same kind of fields, so we need an explicit
         // versioning to know how to mutate the data.
-        if( configVersion<=0) {
+        if (configVersion <= 0) {
             LOGGER.log(Level.CONFIG,
                     "{0} loaded old configuration that had hard-coded underscore at the end of the cloneNamePrefix.",
                     this);
@@ -373,7 +373,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                     + CURRENT_CONFIG_VERSION
                     + ".  Either CURRENT_CONFIG_VERSION is incorrect or the readResolve method is not setting configVersion when it upgrades the data.");
         }
-        if( configVersion > CURRENT_CONFIG_VERSION ) {
+        if (configVersion > CURRENT_CONFIG_VERSION) {
             LOGGER.log(Level.WARNING,
                     "{0} was defined by a later version of the plugin "
                             + "(one that saved with configVersion={1}, whereas this version of the plugin is expecting {2}).  "

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -82,7 +82,9 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
     protected static final SchemeRequirement HTTP_SCHEME = new SchemeRequirement("http");
     protected static final SchemeRequirement HTTPS_SCHEME = new SchemeRequirement("https");
 
-    private final String cloneNamePrefix;
+    private int configVersion;
+    private static final int CURRENT_CONFIG_VERSION = 1;
+    private String cloneNamePrefix; // almost final
     private final String masterImageName;
     private Boolean useSnapshot; // almost final
     private final String snapshotName;
@@ -148,6 +150,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                                      final RetentionStrategy<?> retentionStrategy,
                                      final List<? extends NodeProperty<?>> nodeProperties,
                                      final List<? extends VSphereGuestInfoProperty> guestInfoProperties) {
+        this.configVersion = CURRENT_CONFIG_VERSION;
         this.cloneNamePrefix = cloneNamePrefix;
         this.masterImageName = masterImageName;
         this.snapshotName = snapshotName;
@@ -348,6 +351,38 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             } catch (Exception ex) {
                 LOGGER.log(Level.CONFIG, " - Failed to reconfigure strategy", ex);
             }
+        }
+        // Earlier versions of the code may have stored configuration in a
+        // different way but in the same kind of fields, so we need an explicit
+        // versioning to know how to mutate the data.
+        if( configVersion<=0) {
+            LOGGER.log(Level.CONFIG,
+                    "{0} loaded old configuration that had hard-coded underscore at the end of the cloneNamePrefix.",
+                    this);
+            // In version one, the underscore was removed from the code so we
+            // have to put it in the data (the user is then free to change it to
+            // something else if they want to).
+            this.cloneNamePrefix = this.cloneNamePrefix + "_";
+            configVersion = 1;
+        }
+        // Note: Subsequent changes dependent on configVersion should go above
+        // this line.
+        if (configVersion < CURRENT_CONFIG_VERSION) {
+            throw new IllegalStateException("Internal error: configVersion==" + configVersion
+                    + " at end of readResolve method, but the current config version should be "
+                    + CURRENT_CONFIG_VERSION
+                    + ".  Either CURRENT_CONFIG_VERSION is incorrect or the readResolve method is not setting configVersion when it upgrades the data.");
+        }
+        if( configVersion > CURRENT_CONFIG_VERSION ) {
+            LOGGER.log(Level.WARNING,
+                    "{0} was defined by a later version of the plugin "
+                            + "(one that saved with configVersion={1}, whereas this version of the plugin is expecting {2}).  "
+                            + "The code may not function as expected.",
+                    new Object[]{
+                            this,
+                            configVersion,
+                            CURRENT_CONFIG_VERSION
+                    });
         }
         return this;
     }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithm.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithm.java
@@ -44,15 +44,17 @@ public final class CloudProvisioningAlgorithm {
     }
 
     /**
-     * Chooses a name for a new node.
+     * Chooses a name for a new node. The name will start with the
+     * {@link vSphereCloudSlaveTemplate#getCloneNamePrefix()}.
      * <ul>
      * <li>If the template has a limited number of instances available then the
-     * name will be of the form "prefix_number" where "number" is a number that
-     * should be between 1 and the number of permitted instances.</li>
+     * name will be of the form "prefix<i>number</i>" where "<i>number</i>" is a
+     * number that should be between 1 and the number of permitted instances.
+     * </li>
      * <li>If the template has an unlimited number of instances available then
-     * the name will be of the form "prefix_random" where "random" is a random
-     * UUID's 32-byte number (rendered using a high radix to keep the string
-     * short).</li>
+     * the name will be of the form "prefix<i>random</i>" where "<i>random</i>"
+     * is a random UUID's 32-byte (128 bit) number (rendered using a high radix
+     * to keep the string short).</li>
      * </ul>
      * 
      * @param record

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithm.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithm.java
@@ -70,7 +70,7 @@ public final class CloudProvisioningAlgorithm {
         final int maxAttempts = hasCap ? (templateInstanceCap) : 100;
         for (int attempt = 0; attempt < maxAttempts; attempt++) {
             final String suffix = hasCap ? calcSequentialSuffix(attempt) : calcRandomSuffix(attempt);
-            final String nodeName = cloneNamePrefix + "_" + suffix;
+            final String nodeName = cloneNamePrefix + suffix;
             if (!existingNames.contains(nodeName)) {
                 return nodeName;
             }

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-cloneNamePrefix.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-cloneNamePrefix.html
@@ -1,6 +1,6 @@
 <div>
 Controls the name by which the virtual machine will be known to vSphere.
-The plug-in will append an underscore and a unique ID to this prefix in order to generate unique names.<p>
+The plug-in will append a unique ID to this prefix in order to generate unique names.<p>
 Note: You must ensure that no virtual machines (other than those created by this template) have names starting with this prefix.
 </p>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -200,8 +200,8 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(2, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String expected1 = prefix + "_1";
-        final String expected2 = prefix + "_2";
+        final String expected1 = prefix + "1";
+        final String expected2 = prefix + "2";
 
         // When
         final String actual1 = CloudProvisioningAlgorithm.findUnusedName(record);
@@ -219,10 +219,10 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(3, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String expected1 = prefix + "_1";
-        final String unwanted = prefix + "_2";
+        final String expected1 = prefix + "1";
+        final String unwanted = prefix + "2";
         record.setCurrentlyUnwanted(unwanted, false);
-        final String expected2 = prefix + "_3";
+        final String expected2 = prefix + "3";
 
         // When
         final String actual1 = CloudProvisioningAlgorithm.findUnusedName(record);
@@ -240,9 +240,9 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(3, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String unwanted = prefix + "_1";
-        final String active = prefix + "_2";
-        final String planned = prefix + "_3";
+        final String unwanted = prefix + "1";
+        final String active = prefix + "2";
+        final String planned = prefix + "3";
         record.setCurrentlyUnwanted(unwanted, false);
         record.addCurrentlyActive(active);
         record.addCurrentlyPlanned(planned);
@@ -264,7 +264,7 @@ public class CloudProvisioningAlgorithmTest {
         // Given
         final CloudProvisioningRecord record = createInstance(2, 0, 0);
         final String prefix = record.getTemplate().getCloneNamePrefix();
-        final String expected = prefix + "_1";
+        final String expected = prefix + "1";
 
         // When
         final String actual1 = CloudProvisioningAlgorithm.findUnusedName(record);
@@ -296,7 +296,7 @@ public class CloudProvisioningAlgorithmTest {
         // Then
         final List<String> uniques = new ArrayList<String>(new LinkedHashSet<String>(actuals));
         assertThat(actuals, equalTo(uniques));
-        assertThat(actuals, everyItem(startsWith(prefix + "_")));
+        assertThat(actuals, everyItem(startsWith(prefix)));
     }
 
     private CloudProvisioningRecord createInstance(int capacity, int provisioned, int planned) {


### PR DESCRIPTION
#92 made changes to the functionality to remove the hard-coded underscore between a template's cloneNamePrefix and the random ID in the slave node names.
However, these changes didn't update the online help text, the javadoc, or handle the upgrade path for existing users (who would "suddenly" find their clone names were lacking the underscore after an upgrade).
This PR incorporates #92 but also includes changes to address the above.