### PR TITLE
[WIP] Add VM creation/destruction hook points.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -122,6 +122,13 @@
             </f:dropdownList>
 
             <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties"/>
+
+            <f:entry title="${%Debugging script to run after VM creation}" field="vmCreationHook">
+                <f:textbox/>
+            </f:entry>
+            <f:entry title="${%Debugging script to run before VM disposal}" field="vmDisposalHook">
+                <f:textbox/>
+            </f:entry>
         </f:advanced>
 
         <f:entry title="">

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-vmCreationHook.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-vmCreationHook.html
@@ -1,0 +1,13 @@
+<div>
+If set, specifies a command to be run on the master shortly after a VM has been started.
+Standard variable substitution is in force, plus the variable VSPHERE_IP will be set to the IP address of the VM.
+<p>
+This command is executed after the VM has been created, and after its IP address is known, but before the slave computer is released into Jenkins' control.
+Any command run from here MUST complete quickly.
+The exit code and output from the process will be logged in the vSphere log.
+</p>
+Note: 
+It is an acknowledged problem that debugging slave issues is problematic when the slaves are disposed of shortly after the issue occurs.
+This field, and its sibling, are intended as an aide to debugging such issues.
+They are <em>not</em> intended as robust production-scale functionality.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-vmDisposalHook.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-vmDisposalHook.html
@@ -1,0 +1,15 @@
+<div>
+If set, specifies a command to be run on the master before a VM will be destroyed.
+Standard variable substitution is in force, plus the variable VSPHERE_IP will be set to the IP address of the VM.
+<p>
+This command is executed after Jenkins has determined that it should dispose of the slave, but before the VM is deleted.
+For optimal build performance, any command run from here should complete quickly,
+as any delay will result in the VM continuing to exist and hence count against the instance totals,
+reducing build throughput.
+The exit code and output from the process will be logged in the vSphere log.
+</p>
+Note: 
+It is an acknowledged problem that debugging slave issues is problematic when the slaves are disposed of shortly after the issue occurs.
+This field, and its sibling, are intended as an aide to debugging such issues.
+They are <em>not</em> intended as robust production-scale functionality.
+</div>


### PR DESCRIPTION
Can now get the master to execute arbitrary code just after a VM is created and just before it is destroyed.
That means an admin could write a script to grab important data off the VM before it's destroyed.

We've got issues that are proving difficult to diagnose, and this facility is an attempt at making diagnosis easier.  It it proves useful enough to warrant keeping, I'll ensure it's production-strength; as present, it's intended for non-production usage and debugging only.