### PR TITLE
Fix button text in folder configuration

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/folder/FolderVSphereCloudProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/folder/FolderVSphereCloudProperty/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <f:section title="${%vSphere Cloud}">
         <f:entry title="${%Clouds}" description="${%List of Clouds}">
-            <f:repeatable field="clouds" add="${%Add vSphere Template}">
+            <f:repeatable field="clouds" add="${%Add vSphere Cloud}">
                 <st:include page="config-inner.jelly" class="${descriptor.clazz}"/>
                 <div align="right">
                     <f:repeatableDeleteButton value="${%Delete vSphere Template}"/>


### PR DESCRIPTION
On the folder configuration page, the button for adding a cloud is wrongly labelled _Add vSphere Template_, see

![add-vsphere-template](https://user-images.githubusercontent.com/2901725/47432203-e795ed80-d79d-11e8-97b9-30ddb09a2ed2.png)