### PR TITLE
[JENKINS-60029] - mark VSphereCloudRetentionStrategy as an extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,19 @@
             <artifactId>workflow-basic-steps</artifactId>
             <version>2.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.32</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.32</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -182,8 +182,8 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         this.targetResourcePool = targetResourcePool;
         this.targetHost = targetHost;
         this.credentialsId = credentialsId;
-        this.nodeProperties = nodeProperties;
-        this.guestInfoProperties = guestInfoProperties;
+        this.nodeProperties = Util.fixNull(nodeProperties);
+        this.guestInfoProperties = Util.fixNull(guestInfoProperties);
         this.launcher = launcher;
         this.retentionStrategy = retentionStrategy;
         readResolve();

--- a/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
@@ -16,6 +16,7 @@
 
 package org.jenkinsci.plugins.vsphere;
 
+import hudson.Extension;
 import hudson.model.ExecutorListener;
 import hudson.model.Descriptor;
 import hudson.model.Executor;
@@ -168,6 +169,7 @@ public class RunOnceCloudRetentionStrategy extends CloudRetentionStrategy implem
     }
 
     @Restricted(NoExternalUse.class)
+    @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static final class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.vsphere;
 
+import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
@@ -28,6 +29,7 @@ public class VSphereCloudRetentionStrategy extends CloudRetentionStrategy {
     }
 
     @Restricted(NoExternalUse.class)
+    @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static final class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
@@ -1,0 +1,94 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import hudson.model.Node.Mode;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.JNLPLauncher;
+import hudson.slaves.RetentionStrategy;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import java.util.List;
+import org.jenkinsci.plugins.vSphereCloud;
+import org.jenkinsci.plugins.vSphereCloudSlaveTemplate;
+import org.jenkinsci.plugins.vsphere.RunOnceCloudRetentionStrategy;
+import org.jenkinsci.plugins.vsphere.VSphereGuestInfoProperty;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+public class ConfigurationAsCodeTest {
+
+    @ClassRule
+    @ConfiguredWithCode("configuration-as-code.yml")
+    public static JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    public void should_support_configuration_as_code() {
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        assertThat(cloud.getVsDescription(), is("Company vSphere"));
+        assertThat(cloud.getVsHost(), is("https://company-vsphere"));
+        assertThat(cloud.getInstanceCap(), is(100));
+        assertThat(cloud.getMaxOnlineSlaves(), is(0));
+        List<? extends vSphereCloudSlaveTemplate> templates = cloud.getTemplates();
+        assertThat(templates, hasSize(1));
+        vSphereCloudSlaveTemplate template = templates.get(0);
+        assertThat(template, notNullValue());
+        assertThat(template.getCloneNamePrefix(), is("windows-"));
+        assertThat(template.getCluster(), is("Company"));
+        assertThat(template.getDatastore(), is("Company-FMD-01"));
+
+        assertThat(template.getForceVMLaunch(), is(true));
+        assertThat(template.getLabelString(), is("windows vsphere"));
+        assertThat(template.getLaunchDelay(), is(60));
+        assertThat(template.getLimitedRunCount(), is(1));
+        assertThat(template.getLinkedClone(), is(true));
+        assertThat(template.getMasterImageName(), is("windows-server-2019"));
+        assertThat(template.getMode(), is(Mode.EXCLUSIVE));
+        assertThat(template.getNumberOfExecutors(), is(1));
+        assertThat(template.getRemoteFS(), is("C:/jenkins"));
+        assertThat(template.getResourcePool(), is("Resources"));
+        assertThat(template.getSaveFailure(), is(false));
+        assertThat(template.getTemplateInstanceCap(), is(5));
+        assertThat(template.getUseSnapshot(), is(true));
+        assertThat(template.getWaitForVMTools(), is(true));
+        List<? extends VSphereGuestInfoProperty> guestInfoProperties = template.getGuestInfoProperties();
+        assertThat(guestInfoProperties, hasSize(1));
+        VSphereGuestInfoProperty guestInfoProperty = guestInfoProperties.get(0);
+        assertThat(guestInfoProperty, notNullValue());
+        assertThat(guestInfoProperty.getName(), is("JENKINS_URL"));
+        assertThat(guestInfoProperty.getValue(), is("${JENKINS_URL}"));
+        ComputerLauncher launcher = template.getLauncher();
+        assertThat(launcher, notNullValue());
+        assertThat(launcher, instanceOf(JNLPLauncher.class));
+        JNLPLauncher jnlpLauncher = (JNLPLauncher) launcher;
+        assertThat(jnlpLauncher.tunnel, is("jenkins:"));
+        RetentionStrategy<?> retentionStrategy = template.getRetentionStrategy();
+        assertThat(retentionStrategy, notNullValue());
+        assertThat(retentionStrategy, instanceOf(RunOnceCloudRetentionStrategy.class));
+        RunOnceCloudRetentionStrategy runOnce = (RunOnceCloudRetentionStrategy) retentionStrategy;
+        assertThat(runOnce.getIdleMinutes(), is(2));
+    }
+
+    @Test
+    public void should_support_configuration_export() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        final CNode cloud = getJenkinsRoot(context).get("clouds");
+
+        String exported = toYamlString(cloud);
+
+        String expected = toStringFromYamlFile(this, "expected_output.yml");
+
+        assertThat(exported, is(expected));
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code.yml
@@ -1,0 +1,40 @@
+jenkins:
+  systemMessage: "Hello World"
+  agentProtocols:
+    - "JNLP4-connect"
+  clouds:
+    - vSphere:
+        instanceCap: 100
+        maxOnlineSlaves: 0
+        templates:
+          - cloneNamePrefix: "windows-"
+            cluster: "Company"
+            datastore: "Company-FMD-01"
+            folder: "Company/Jenkins agents/Linked clones"
+            forceVMLaunch: true
+            guestInfoProperties:
+              # ^ escapes the secret
+              - name: "JENKINS_URL"
+                value: "^${JENKINS_URL}"
+            labelString: "windows vsphere"
+            launchDelay: 60
+            launcher:
+              jnlp:
+                tunnel: "jenkins:"
+            limitedRunCount: 1
+            linkedClone: true
+            masterImageName: "windows-server-2019"
+            mode: EXCLUSIVE
+            numberOfExecutors: 1
+            remoteFS: "C:/jenkins"
+            resourcePool: "Resources"
+            retentionStrategy:
+              runOnceCloud:
+                idleMinutes: 2
+            saveFailure: false
+            templateInstanceCap: 5
+            useSnapshot: true
+            waitForVMTools: true
+        vsConnectionConfig:
+          vsHost: "https://company-vsphere"
+        vsDescription: "Company vSphere"

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
@@ -1,0 +1,34 @@
+- vSphere:
+    instanceCap: 100
+    maxOnlineSlaves: 0
+    templates:
+    - cloneNamePrefix: "windows-"
+      cluster: "Company"
+      datastore: "Company-FMD-01"
+      folder: "Company/Jenkins agents/Linked clones"
+      forceVMLaunch: true
+      guestInfoProperties:
+      - name: "JENKINS_URL"
+        value: "^${JENKINS_URL}"
+      labelString: "windows vsphere"
+      launchDelay: 60
+      launcher:
+        jnlp:
+          tunnel: "jenkins:"
+      limitedRunCount: 1
+      linkedClone: true
+      masterImageName: "windows-server-2019"
+      mode: EXCLUSIVE
+      numberOfExecutors: 1
+      remoteFS: "C:/jenkins"
+      resourcePool: "Resources"
+      retentionStrategy:
+        runOnceCloud:
+          idleMinutes: 2
+      saveFailure: false
+      templateInstanceCap: 5
+      useSnapshot: true
+      waitForVMTools: true
+    vsConnectionConfig:
+      vsHost: "https://company-vsphere"
+    vsDescription: "Company vSphere"


### PR DESCRIPTION
fixes [JENKINS-60029](https://issues.jenkins-ci.org/browse/JENKINS-60029)

This should fix vSphere cloud retention strategy not being configurable from JCasc.

I might be interested in giving the plugin a little love.