### PR TITLE
[JENKINS-57967] Pass SshHostKeyVerificationStrategy to SSHLauncher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
          <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.11</version>
+            <version>1.15</version>
          </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -332,7 +332,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                 final String oldCredentialsIdOrNull = getCredentialsId();
                 final String oldCredentialsId = oldCredentialsIdOrNull == null ? "" : oldCredentialsIdOrNull;
                 // these were the old hard-coded settings
-                this.launcher = new SSHLauncher(null, 0, oldCredentialsId, null, null, null, null, this.launchDelay, 3, 60);
+                this.launcher = new SSHLauncher(null, 0, oldCredentialsId, null, null, null, null, this.launchDelay, 3, 60, null);
                 LOGGER.log(Level.CONFIG, " - now configured to use {0}(..., {1}, ...)", new Object[] {
                         this.launcher.getClass().getSimpleName(), oldCredentialsId });
             } catch (Exception ex) {
@@ -478,7 +478,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                     sshLauncher.getCredentialsId(), sshLauncher.getJvmOptions(), sshLauncher.getJavaPath(),
                     sshLauncher.getPrefixStartSlaveCmd(), sshLauncher.getSuffixStartSlaveCmd(),
                     sshLauncher.getLaunchTimeoutSeconds(), sshLauncher.getMaxNumRetries(),
-                    sshLauncher.getRetryWaitTime());
+                    sshLauncher.getRetryWaitTime(), sshLauncher.getSshHostKeyVerificationStrategy());
             return launcherWithIPAddress;
         }
         throw new IllegalStateException("Unsupported launcher (" + launcher + ") in template configuration");


### PR DESCRIPTION
Previous version of the constructor was removed in SSH Slaves 1.30.0. Fixes problem detailed in https://issues.jenkins-ci.org/browse/JENKINS-57967.