### PR TITLE
Fix NodeProperties config on vSphere template

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>vsphere-cloud</artifactId>
-    <version>2.21-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>vSphere Plugin</name>
@@ -45,6 +45,8 @@
     </scm>
 
     <properties>
+        <revision>2.21</revision>
+        <changelist>-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -616,7 +616,7 @@ public class vSphereCloud extends Cloud {
 
             TopLevelItem topLevelItem = null;
             if (prevFolder == null) {
-                topLevelItem = Jenkins.getActiveInstance().getItem(item);
+                topLevelItem = Jenkins.getInstance().getItem(item);
             } else {
                 Collection<TopLevelItem> items = prevFolder.getItems();
                 for (TopLevelItem levelItem : items) {

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -30,6 +30,7 @@ import hudson.model.Node.Mode;
 import hudson.model.labels.LabelAtom;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
 import hudson.slaves.CommandLauncher;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
@@ -48,6 +49,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.Nonnull;
+
 import jenkins.model.Jenkins;
 import jenkins.slaves.JnlpSlaveAgentProtocol;
 
@@ -59,6 +62,8 @@ import org.jenkinsci.plugins.vsphere.builders.Messages;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereDuplicateException;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -426,7 +431,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                 LOGGER.log(Level.SEVERE, "VM {0} name clashes with one we wanted to use, but it wasn't started by this plugin.", cloneName );
                 throw ex;
             }
-            final String ourJenkinsUrl = Jenkins.getActiveInstance().getRootUrl();
+            final String ourJenkinsUrl = Jenkins.getInstance().getRootUrl();
             if ( vmJenkinsUrl.equals(ourJenkinsUrl) ) {
                 LOGGER.log(Level.INFO, "Found existing VM {0} that we started previously (and must have either lost track of it or failed to delete it).", cloneName );
             } else {
@@ -608,6 +613,27 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             result.add(VSphereCloudRetentionStrategy.DESCRIPTOR);
             return result;
         }
+
+        /**
+         * Returns the list of {@link NodePropertyDescriptor} appropriate for the
+         * {@link vSphereCloudSlave}s that are created from this template.
+         *
+         * @return the filtered list
+         */
+        @SuppressWarnings("unchecked")
+        @Nonnull
+        @Restricted(NoExternalUse.class) // used by Jelly EL only
+        public List<NodePropertyDescriptor> getNodePropertiesDescriptors() {
+            List<NodePropertyDescriptor> result = new ArrayList<NodePropertyDescriptor>();
+            final Jenkins j = Jenkins.getInstance();
+            final List<NodePropertyDescriptor> list = j.getDescriptorList(NodeProperty.class);
+            for (NodePropertyDescriptor npd : list) {
+                if (npd.isApplicable(vSphereCloudSlave.class)) {
+                    result.add(npd);
+                }
+            }
+            return result;
+        }
     }
 
     private static String findWhichJenkinsThisVMBelongsTo(final VSphere vSphere, String cloneName) {
@@ -645,7 +671,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             throws IOException, InterruptedException {
         final EnvVars knownVariables = calculateVariablesForGuestInfo(cloneName, listener);
         final Map<String, String> result = new LinkedHashMap<String, String>();
-        final String jenkinsUrl = Jenkins.getActiveInstance().getRootUrl();
+        final String jenkinsUrl = Jenkins.getInstance().getRootUrl();
         if (jenkinsUrl != null) {
             result.put(VSPHERE_ATTR_FOR_JENKINSURL, jenkinsUrl);
         }
@@ -667,7 +693,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         final EnvVars knownVariables = new EnvVars();
         // Maintenance note: If you update this method, you must also update the
         // UI help page to match.
-        final String jenkinsUrl = Jenkins.getActiveInstance().getRootUrl();
+        final String jenkinsUrl = Jenkins.getInstance().getRootUrl();
         if (jenkinsUrl != null) {
             addEnvVar(knownVariables, "JENKINS_URL", jenkinsUrl);
             addEnvVar(knownVariables, "HUDSON_URL", jenkinsUrl);

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -456,7 +456,11 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             final ComputerLauncher configuredLauncher = determineLauncher(vSphere, cloneName);
             final RetentionStrategy<?> configuredStrategy = determineRetention();
             final String snapshotNameForLauncher = ""; /* we don't make the launcher do anything with snapshots because our clone won't be created with any */
-            slave = new vSphereCloudProvisionedSlave(cloneName, this.templateDescription, this.remoteFS, String.valueOf(this.numberOfExecutors), this.mode, this.labelString, configuredLauncher, configuredStrategy, this.nodeProperties, this.parent.getVsDescription(), cloneName, this.forceVMLaunch, this.waitForVMTools, snapshotNameForLauncher, String.valueOf(this.launchDelay), null, String.valueOf(this.limitedRunCount));
+            slave = new vSphereCloudProvisionedSlave(cloneName, getTemplateDescription(), getRemoteFS(),
+                    String.valueOf(getNumberOfExecutors()), getMode(), getLabelString(), configuredLauncher,
+                    configuredStrategy, Util.fixNull(getNodeProperties()), getParent().getVsDescription(), cloneName,
+                    getForceVMLaunch(), getWaitForVMTools(), snapshotNameForLauncher, String.valueOf(getLaunchDelay()),
+                    null, String.valueOf(getLimitedRunCount()));
         } finally {
             // if anything went wrong, try to tidy up
             if( slave==null ) {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
@@ -163,7 +163,7 @@ public class VSphereBuildStepContainer extends Builder implements SimpleBuildSte
 
                     TopLevelItem topLevelItem = null;
                     if (prevFolder == null) {
-                        topLevelItem = Jenkins.getActiveInstance().getItem(item);
+                        topLevelItem = Jenkins.getInstance().getItem(item);
                     } else {
                         Collection<TopLevelItem> items = prevFolder.getItems();
                         for (TopLevelItem levelItem : items) {

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -121,7 +121,10 @@
                 </j:forEach>
             </f:dropdownList>
 
-            <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties"/>
+            <f:entry title="Node Properties">
+                <f:repeatableHeteroProperty field="nodeProperties" oneEach="true" hasHeader="true"
+                                            addCaption="Add Node Property" deleteCaption="Delete Node Property"/>
+            </f:entry>
         </f:advanced>
 
         <f:entry title="">

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -72,7 +72,7 @@
                 <f:checkbox/>
             </f:entry>
 
-            <f:entry title="${%Delay between launch and boot complete}" field="launchDelay" description="${%Number of seconds.}">
+            <f:entry title="${%Delay in seconds}" field="launchDelay">
                 <f:textbox clazz="required number" default="60"/>
             </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereConnectionConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereConnectionConfig/config.groovy
@@ -7,7 +7,7 @@ f.entry(title:_("vSphere Host"), field:"vsHost") {
     f.textbox()
 }
 
-f.entry(title:_("Disable Certificate Verification"), field:"allowUntrustedCertificate") {
+f.entry(title:_("Disable SSL Check"), field:"allowUntrustedCertificate") {
     f.checkbox()
 }
 


### PR DESCRIPTION
Existing config WebUI doesn't list all possible node properties, limiting what folks can enter.  It should allow folks to specify any node properties that are suitable for the vSphere nodes.

This code change lets you add any node properties to a vSphere template.
It also fixes (well, bypasses) the problem whereby the existing configured node properties don't get loaded into the WebUI properly such that, unless the user re-enters them, they'll get wiped on save (not sure why that was happening, but this code change stops it happening).

This will resolve [JENKINS-41428](https://issues.jenkins-ci.org/browse/JENKINS-41428) and [JENKINS-46375](https://issues.jenkins-ci.org/browse/JENKINS-46375).