### PR TITLE
[JENKINS-58136] Fix graceful shutdown appearing unchecked on config page load.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/PowerOff/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/PowerOff/config.jelly
@@ -26,7 +26,7 @@ limitations under the License.
   <f:entry title="${%If suspended?}" field="evenIfSuspended">
     <f:checkbox />
   </f:entry>
-  <f:optionalBlock title="${%Shutdown gracefully?}" field="shutdownGracefully" checked="false" inline="true">
+  <f:optionalBlock title="${%Shutdown gracefully?}" field="shutdownGracefully" inline="true">
     <f:entry title="${%Gracefully shutdown timeout}" field="gracefulShutdownTimeout">
       <f:number default="180" />
     </f:entry>


### PR DESCRIPTION
Fix for [JENKINS-58136](https://issues.jenkins-ci.org/browse/JENKINS-58136) as requested. My bad!

Tested on Jenkins 1.625.3 and 2.138.3.