### PR TITLE
fix value accessor

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/parameters/CloudSelectorParameter.java
@@ -35,8 +35,10 @@ public class CloudSelectorParameter extends SimpleParameterDefinition {
 
     private StringParameterValue checkValue(StringParameterValue value) {
         List<String> cloudNames = vSphereCloud.findAllVsphereCloudNames();
-        if (!cloudNames.contains(value.value))
-            throw new IllegalArgumentException("No vsphere cloud with name: " + value.value);
+        String check = String.valueOf(value.getValue());
+        if (!cloudNames.contains(check)) {
+            throw new IllegalArgumentException("No vsphere cloud with name: " + check);
+        }
         return value;
     }
 


### PR DESCRIPTION
Fix accessor usage in CloudSelectorParameter as `.value` is (about to be) prohibited.