### PR TITLE
[JENKINS-61131] Fix broken credentials selection

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereConnectionConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereConnectionConfig.java
@@ -142,7 +142,7 @@ public class VSphereConnectionConfig extends AbstractDescribableImpl<VSphereConn
                 @QueryParameter String vsHost) {
             throwUnlessUserHasPermissionToConfigureCloud(containingFolderOrNull);
             return new StandardListBoxModel().includeEmptyValue()
-                .includeMatching(Jenkins.getInstance(), StandardCredentials.class,
+                .includeMatchingAs(ACL.SYSTEM, Jenkins.getInstance(), StandardCredentials.class,
                     Collections.singletonList(getDomainRequirement(vsHost)), CREDENTIALS_MATCHER);
         }
 


### PR DESCRIPTION
Fixes [JENKINS-61131](https://issues.jenkins-ci.org/browse/JENKINS-61131).

#110 changed the population of the credentials selection to no longer use deprecated api.
Credentials are now resolved in the context of `Jenkins.getAuthentication()`, which does not return any matches.

According to the [documentation of the credentials-plugin](https://github.com/jenkinsci/credentials-plugin/blob/master/docs/consumer.adoc#listing-available-credentials-matching-some-specific-set-of-criteria), interactive lookups on the main
configuration page should be performed as `ACL.SYSTEM`.

Signed-off-by: Harald Albers <github@albersweb.de>