### PR TITLE
Fix leak of launcher on disconnect

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -282,18 +282,20 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
     public synchronized void afterDisconnect(SlaveComputer slaveComputer, TaskListener taskListener) {
         final vSphereCloudSlave vsSlave = (vSphereCloudSlave) slaveComputer.getNode();
 
-        if(vsSlave == null) {
-            vSphereCloud.Log(slaveComputer, taskListener, "Slave is null.");
-            return;
+        if (vsSlave != null) {
+            if (vsSlave.slaveIsStarting == Boolean.TRUE) {
+                vSphereCloud.Log(slaveComputer, taskListener, "Ignoring disconnect attempt because a connect attempt is in progress.");
+                return;
+            }
+            if (vsSlave.slaveIsDisconnecting == Boolean.TRUE) {
+                vSphereCloud.Log(slaveComputer, taskListener, "Already disconnecting on a separate thread");
+                return;
+            }
+            vsSlave.slaveIsDisconnecting = Boolean.TRUE;
+        } else {
+            vSphereCloud.Log(slaveComputer, taskListener, "Slave is null. Will still attempt to tear down launcher.");
         }
-        if (vsSlave.slaveIsStarting == Boolean.TRUE) {
-            vSphereCloud.Log(slaveComputer, taskListener, "Ignoring disconnect attempt because a connect attempt is in progress.");
-            return;
-        }
-        if (vsSlave.slaveIsDisconnecting == Boolean.TRUE) {
-            vSphereCloud.Log(slaveComputer, taskListener, "Already disconnecting on a separate thread");
-            return;
-        }
+
         if (slaveComputer.isTemporarilyOffline()) {
             if (!(slaveComputer.getOfflineCause() instanceof VSphereOfflineCause)) {
                 vSphereCloud.Log(slaveComputer, taskListener, "Not disconnecting VM because it's not accepting tasks");
@@ -301,7 +303,6 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
             }
         }
 
-        vsSlave.slaveIsDisconnecting = Boolean.TRUE;
         VSphere v = null;
         boolean reconnect = false;
         try {
@@ -380,8 +381,10 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                 v.disconnect();
                 v = null;
             }
-            vsSlave.slaveIsDisconnecting = Boolean.FALSE;
-            vsSlave.slaveIsStarting = Boolean.FALSE;
+            if (vsSlave != null) {
+                vsSlave.slaveIsDisconnecting = Boolean.FALSE;
+                vsSlave.slaveIsStarting = Boolean.FALSE;
+            }
 
             if (reconnect) {
                 slaveComputer.connect(false);


### PR DESCRIPTION
I have found that the vSphere Cloud plugin does not always tear down the underlying launcher when it is tearing down its build slaves. In my configuration, this leads to a leak of SSH sockets. 
My environment makes almost exclusive use of run-once vSphere templates using the SSH launch agent, executing ~2000 per day. We've noticed that our Jenkins instance will accumulate ESTABLISHED TCP sockets to SSH services on vSphere hosts at a rate of ~1000 per week. Over time, this can lead to an exhaustion of file handles.

A simple reproduction involves:

1. Create a vSphere template that:
   - Uses an SSH Launch agent
   - Configured for the Run-Once strategy
   - Number of Executors: 1
   - Disconnect After Limited Builds: 1
2. Create a pipeline job that spins up 10 of these nodes in parallel:
```
def parallelJobs = [:]

10.times {
    def c = it
    parallelJobs["job${c}"] = {
        node("centos7") {
            echo "Hello World: ${c}"
        }
    }
}

parallel(parallelJobs)
```
3. Launch the pipeline several times in a row.

Running lsof on against the jenkins process (ex: 12345) shows an accumulation of SSH sockets for build slaves that no longer exist:
```
$ lsof -n -P -p 12345|grep TCP
....
java    3309 jenkins 1852u     IPv4         1373870262       0t0        TCP 10.1.1.2:49784->10.2.1.229:22 (ESTABLISHED)
java    3309 jenkins 1862u     IPv4         1319015182       0t0        TCP 10.1.1.2:58112->10.2.1.55:22 (ESTABLISHED)
java    3309 jenkins 1888u     IPv4         1373865499       0t0        TCP 10.1.1.2:35440->10.2.1.230:22 (ESTABLISHED)
java    3309 jenkins 1922u     IPv4         1359700779       0t0        TCP 10.1.1.2:48134->10.2.1.9:22 (ESTABLISHED)
java    3309 jenkins 1939u     IPv4         1360881203       0t0        TCP 10.1.1.2:38708->10.2.1.104:22 (ESTABLISHED)
java    3309 jenkins 1943u     IPv4         1360808902       0t0        TCP 10.1.1.2:37400->10.2.1.90:22 (ESTABLISHED)
java    3309 jenkins 2003u     IPv4         1359902180       0t0        TCP 10.1.1.2:52876->10.2.1.245:22 (ESTABLISHED)

....
```

#### Cause
`vSphereCloudLauncher.afterDisconnect` would not call through to the underlying launcher's `afterDisconnect` when `slaveComputer.getNode()` returned null. This is problematic because SSHLauncher's teardown of the socket relies on its `afterDisconnect` being called. 

According to the [documentation for afterDisconnect](https://javadoc.jenkins.io/hudson/slaves/ComputerLauncher.html#afterDisconnect-hudson.slaves.SlaveComputer-hudson.model.TaskListener-):

> Disconnect operation is performed asynchronously, so there's no guarantee that the corresponding SlaveComputer exists for the duration of the operation.

I found it helpful to [implement a NodeListener](https://gist.github.com/justfalter/77c1af8c3ae44db5a80e285465b858ef) that would let me know when the node was deleted. In cases where the leak occurs, I would see a `NODE DELETED: mynode1` message, followed by a `Slave is null`. 

#### Fix
Modify `vSphereCloudLauncher.afterDisconnect` so that it calls through to the launcher's `afterDisconnect` even though `slaveComputer.getNode()` may have returned null.


#### Caveats
- There is a lot going on in `vSphereCloudLauncher.afterDisconnect`, and I am unable to confirm that the changes I've made affect those code paths. Almost none of it is in the code path for my environment (our vsphere templates always seem to have an idle action of `NOTHING`). 
- `afterDisconnect` will be called multiple times --- I don't know if this is problematic for the idle action code. If it is, then it might be a good idea to move that code outside of `afterDisconnect`.. 