### PR TITLE
docs: Update terminology from 'slave' to 'agent'

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-instanceCap.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-instanceCap.html
@@ -1,5 +1,5 @@
 <div>
-Maximum number of template slave instance virtual machines that this vSphere Cloud should use at one time.<br/>
+Maximum number of template agent instance virtual machines that this vSphere Cloud should use at one time.<br/>
 A value of 0 indicates no maximum value.<br/>
 This limit applies only to machines started as a result of vSphere Template slaves (defined below).
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-idleOption.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-idleOption.html
@@ -1,4 +1,4 @@
-<div>What should be done when the slave disconnects.
+<div>What should be done when the agent disconnects.
     <ul>
         <li><b>Shutdown</b>: Shuts the virtual machine down, first attempting a Guest shutdown if VMware tools are installed, then a hard power off if VMware tools is not installed or the Guest shutdown fails.</li>
         <li><b>Revert</b>: Shuts down the virtual machine like <b>Shutdown</b>, then reverts. If a snapshot name is specified, the revert will be to that snapshot.</li>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-launchDelay.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-launchDelay.html
@@ -1,9 +1,9 @@
 <div>
 Time (in seconds) to wait, after starting the VM, and (if selected) after the VMware tools have started.
 <ul>
-<li>If the slave is responsible for connecting to the master (e.g. JNLP) then this is
-the maximum amount of time that the master will wait for the slave to come online before timing out.</li>
-<li>If the master is responsible for connecting to the slave (e.g. SSH) then this is
+<li>If the agent is responsible for connecting to the master (e.g. JNLP) then this is
+the maximum amount of time that the master will wait for the agent to come online before timing out.</li>
+<li>If the master is responsible for connecting to the agent (e.g. SSH) then this is
 the exact amount of time that the master will delay before commencing the connection process.</li>
 </ul>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-vmName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-vmName.html
@@ -1,6 +1,6 @@
 <div>Name of the virtual machine as it appears in vSphere. 
     <p>If more than one agent uses the same virtual machine name, only one at 
-        time will be started; this would be the case where a agent machine is 
+        time will be started; this would be the case where an agent machine is 
         associated with a virtual machine AND a snapshot.  This allows Jenkins 
         to use the same virtual machine but with different agent options or
         a snapshot.

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-vmName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-vmName.html
@@ -1,7 +1,7 @@
 <div>Name of the virtual machine as it appears in vSphere. 
-    <p>If more than one slave uses the same virtual machine name, only one at 
-        time will be started; this would be the case where a slave machine is 
+    <p>If more than one agent uses the same virtual machine name, only one at 
+        time will be started; this would be the case where a agent machine is 
         associated with a virtual machine AND a snapshot.  This allows Jenkins 
-        to use the same virtual machine but with different slave options or
+        to use the same virtual machine but with different agent options or
         a snapshot.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-vsDescription.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-vsDescription.html
@@ -1,1 +1,1 @@
-<div>Name of the vSphere Cloud that this slave machine exists on.</div>
+<div>Name of the vSphere Cloud that this agent machine exists on.</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-waitForVMTools.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlave/help-waitForVMTools.html
@@ -1,1 +1,1 @@
-<div>If enabled, and the virtual machine is started by Jenkins, Jenkins will wait for VMware Tools to become active before allowing the slave to take any jobs. Only useful if VMware Tools is installed on the virtual machine.</div>
+<div>If enabled, and the virtual machine is started by Jenkins, Jenkins will wait for VMware Tools to become active before allowing the agent to take any jobs. Only useful if VMware Tools is installed on the virtual machine.</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-forceVMLaunch.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-forceVMLaunch.html
@@ -1,13 +1,13 @@
 <div>
-	If you are using a Launch method where the slave connects to the
+	If you are using a Launch method where the agent connects to the
 	master, e.g. Java Web Start, then tick this box.
 	<p>
 		Each launch method tells Jenkins whether or not the Jenkins master can
 		initiate the process itself or not. In the case of "passive" methods
 		where the Jenkins master takes no action itself, Jenkins will be
-		(mis)informed that it is unable to take action to start the slave. <br />
+		(mis)informed that it is unable to take action to start the agent. <br />
 		This flag overrides that information. <br /> This is appropriate for
-		cloud-provisioned slaves because the act of creating the slave (which
-		the Jenkins master can do) should trigger the slave's connection.
+		cloud-provisioned agents because the act of creating the agent (which
+		the Jenkins master can do) should trigger the agent's connection.
 	</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-guestInfoProperties.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-guestInfoProperties.html
@@ -19,7 +19,7 @@ Variables which can be used within the values of these properties include
 <tt>NODE_NAME</tt>,
 <tt>NODE_LABELS</tt>.
 </li>
-<li>The value to be passed with the <tt>-secret</tt> argument if the slave is connecting via JNLP: <tt>JNLP_SECRET</tt>.</li>
+<li>The value to be passed with the <tt>-secret</tt> argument if the agent is connecting via JNLP: <tt>JNLP_SECRET</tt>.</li>
 <li>The following properties from this vSphere template definition:
 <tt>cluster</tt>,
 <tt>datastore</tt>,

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-launchDelay.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-launchDelay.html
@@ -1,9 +1,9 @@
 <div>
 Time, in seconds, to wait after starting the VM, and after the VMware tools have started.
 <dl>
-<dt>If the slave is responsible for connecting to the master (e.g. JNLP) then this is:</dt>
-<dd>the maximum amount of time that the master will wait for the slave to come online before timing out.</dd>
-<dt>If the master is responsible for connecting to the slave (e.g. SSH) then this is:</dt>
+<dt>If the agent is responsible for connecting to the master (e.g. JNLP) then this is:</dt>
+<dd>the maximum amount of time that the master will wait for the agent to come online before timing out.</dd>
+<dt>If the master is responsible for connecting to the agent (e.g. SSH) then this is:</dt>
 <dd>the exact amount of time that the master will delay before starting that process.</dd>
 </dl>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-launcher.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-launcher.html
@@ -1,14 +1,14 @@
 <div>
-Specifies the method by which the Jenkins slave agent will be launched on the slave.
+Specifies the method by which the Jenkins agent will be launched.
 <dl>
 <dt>Java Web Start</dt>
 <dd>Relies on processes within the virtual machine to connect to Jenkins.
 If you use this, you may find it useful to use GuestInfo Properties to pass data to the virtual machine telling it where to connect to.</dd>
 <dt>Execution of command</dt>
-<dd>The Jenkins master machine runs a command the connect to this slave.</dd>
+<dd>The Jenkins master machine runs a command the connect to this agent.</dd>
 <dt>SSH (default)</dt>
-<dd>The Jenkins master logs into the slave via SSH, using the credentials specified, and uses that session to push the slave code onto the slave and then run it.
-You should leave the "host" field blank as the plugin will automatically fill that in itself (once it knows the IP address of the slave).
+<dd>The Jenkins master logs into the agent via SSH, using the credentials specified, and uses that session to push the agent code onto the agent and then run it.
+You should leave the "host" field blank as the plugin will automatically fill that in itself (once it knows the IP address of the agent).
 </dd>
 </dl>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-limitedRunCount.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-limitedRunCount.html
@@ -1,9 +1,9 @@
 <div>
 If the value is greater than 0; this will limit the number of builds
-(from any job) allowed on this slave before the slave is disconnected.
+(from any job) allowed on this agent before the agent is disconnected.
 <br/>
-When the slave-agent is disconnected, the disconnect action will be performed.
-This can, for example, reboot the slave.
+When the agent is disconnected, the disconnect action will be performed.
+This can, for example, reboot the agent.
 It does NOT destroy the VM.
 <br/>
 Use 0 to disable this feature.

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-retentionStrategy.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-retentionStrategy.html
@@ -1,9 +1,9 @@
 <div>
-Says whether to use the slave once and then immediately dispose of it, or to keep the slave until it is no longer required.
+Says whether to use the agent once and then immediately dispose of it, or to keep the agent until it is no longer required.
 <ul>
 <li>If you use the run-once strategy, you should ensure that there is only 1 executor.</li>
 <li>If you use the keep-until-idle strategy, you should ensure that "disconnect after limited builds" is disabled (set to 0).</li>
 </ul>
-Both these options have an idle timeout (in minutes) after which to kill the slave, but for a run-once strategy, this is only a fail-safe if the slave fails to connect.
-Normally a run-once slave will be terminated immediately after it has completed its one-and-only job.
+Both these options have an idle timeout (in minutes) after which to kill the slave, but for a run-once strategy, this is only a fail-safe if the agent fails to connect.
+Normally a run-once agent will be terminated immediately after it has completed its one-and-only job.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-waitForVMTools.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-waitForVMTools.html
@@ -1,6 +1,6 @@
 <div>
 	If enabled, Jenkins will wait for VMware Tools to become active before
-	continuing with the slave connection process.
+	continuing with the agent connection process.
 	<p>This effectively makes the Launch Delay timer to be relative to
 		the time when the virtual machine is "up" rather than requiring a
 		longer Launch Delay timer (to cope with variations in startup speeds).

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-idleOption.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-idleOption.html
@@ -1,4 +1,4 @@
-<div>What should be done when the slave disconnects.
+<div>What should be done when the agent disconnects.
     <ul>
         <li><b>Shutdown</b>: Shuts the virtual machine down, first attempting a Guest shutdown if VMware tools are installed, then a hard power off if VMware tools is not installed or the Guest shutdown fails.</li>
         <li><b>Revert</b>: Shuts down the virtual machine like <b>Shutdown</b>, then reverts. If a snapshot name is specified, the revert will be to that snapshot.</li>

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-launchDelay.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-launchDelay.html
@@ -1,9 +1,9 @@
 <div>
 Time, in seconds, to wait after starting the VM, and after the VMware tools have started.
 <dl>
-<dt>If the slave is responsible for connecting to the master (e.g. JNLP) then this is:</dt>
-<dd>the maximum amount of time that the master will wait for the slave to come online before timing out.</dd>
-<dt>If the master is responsible for connecting to the slave (e.g. SSH) then this is:</dt>
+<dt>If the agent is responsible for connecting to the master (e.g. JNLP) then this is:</dt>
+<dd>the maximum amount of time that the master will wait for the agent to come online before timing out.</dd>
+<dt>If the master is responsible for connecting to the agent (e.g. SSH) then this is:</dt>
 <dd>the exact amount of time that the master will delay before starting that process.</dd>
 </dl>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-vmName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-vmName.html
@@ -1,6 +1,6 @@
 <div>Name of the virtual machine as it appears in vSphere. 
     <p>If more than one agent uses the same virtual machine name, only one at 
-        time will be started; this would be the case where a agent machine is 
+        time will be started; this would be the case where an agent machine is 
         associated with a virtual machine AND a snapshot.  This allows Jenkins 
         to use the same virtual machine but with different agent options or
         a snapshot.

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-vmName.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-vmName.html
@@ -1,7 +1,7 @@
 <div>Name of the virtual machine as it appears in vSphere. 
-    <p>If more than one slave uses the same virtual machine name, only one at 
-        time will be started; this would be the case where a slave machine is 
+    <p>If more than one agent uses the same virtual machine name, only one at 
+        time will be started; this would be the case where a agent machine is 
         associated with a virtual machine AND a snapshot.  This allows Jenkins 
-        to use the same virtual machine but with different slave options or
+        to use the same virtual machine but with different agent options or
         a snapshot.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-vsDescription.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-vsDescription.html
@@ -1,1 +1,1 @@
-<div>Name of the vSphere Cloud that this slave machine exists on.</div>
+<div>Name of the vSphere Cloud that this agent machine exists on.</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-waitForVMTools.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphereCloudProvisionedSlave/help-waitForVMTools.html
@@ -1,1 +1,1 @@
-<div>If enabled, and the virtual machine is started by Jenkins, Jenkins will wait for VMware Tools to become active before allowing the slave to take any jobs. Only useful if VMware Tools is installed on the virtual machine.</div>
+<div>If enabled, and the virtual machine is started by Jenkins, Jenkins will wait for VMware Tools to become active before allowing the agent to take any jobs. Only useful if VMware Tools is installed on the virtual machine.</div>


### PR DESCRIPTION
Jenkins was designed with a "master <-> slave" architecture. 'slave' is deprecated and 'agent' should be used instead.
#words-matter
https://www.ibm.com/blogs/think/2020/08/words-matter-driving-thoughtful-change-toward-inclusive-language-in-technology/