### PR TITLE
Support reconfiguring a templated VM during deployment

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureAnnotation.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureAnnotation.java
@@ -56,6 +56,11 @@ public class ReconfigureAnnotation extends ReconfigureStep {
     }
 
     @Override
+    public void perform(@Nonnull EnvVars env, @Nonnull TaskListener listener) throws VSphereException {
+        reconfigureAnnotation(env, listener);
+    }
+
+    @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
         try {
             reconfigureAnnotation(run, launcher, listener);
@@ -77,19 +82,14 @@ public class ReconfigureAnnotation extends ReconfigureStep {
     }
 
     public boolean reconfigureAnnotation(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws VSphereException  {
+        EnvVars env = extractEnvironment(run, listener);
 
+        return reconfigureAnnotation(env, listener);
+    }
+
+    private boolean reconfigureAnnotation(final EnvVars env, final TaskListener listener) throws VSphereException  {
         final PrintStream jLogger = listener.getLogger();
-        String expandedText = getAnnotation();
-        final EnvVars env;
-        try {
-            env = run.getEnvironment(listener);
-        } catch (Exception e) {
-            throw new VSphereException(e);
-        }
-        if (run instanceof AbstractBuild) {
-            env.overrideAll(((AbstractBuild) run).getBuildVariables()); // Add in matrix axes..
-            expandedText = env.expand(expandedText);
-        }
+        String expandedText = env.expand(getAnnotation());
 
         VSphereLogger.vsLogger(jLogger, "Preparing reconfigure: Annotation");
         if (getAppend()) {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureMemory.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureMemory.java
@@ -44,6 +44,11 @@ public class ReconfigureMemory extends ReconfigureStep {
 	}
 
 	@Override
+	public void perform(@Nonnull EnvVars env, @Nonnull TaskListener listener) throws VSphereException {
+		reconfigureMemory(env, listener);
+	}
+
+	@Override
 	public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
 		try {
 			reconfigureMemory(run, launcher, listener);
@@ -65,24 +70,19 @@ public class ReconfigureMemory extends ReconfigureStep {
 	}
 
 	public boolean reconfigureMemory(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws VSphereException  {
+        EnvVars env = extractEnvironment(run, listener);
 
-        PrintStream jLogger = listener.getLogger();
-		String expandedMemorySize = memorySize;
-        EnvVars env;
-        try {
-            env = run.getEnvironment(listener);
-        } catch (Exception e) {
-            throw new VSphereException(e);
-        }
-		if (run instanceof AbstractBuild) {
-			env.overrideAll(((AbstractBuild) run).getBuildVariables()); // Add in matrix axes..
-			expandedMemorySize = env.expand(memorySize);
-		}
+		return reconfigureMemory(env, listener);
+	}
 
-        VSphereLogger.vsLogger(jLogger, "Preparing reconfigure: Memory");
-        spec.setMemoryMB(Long.valueOf(expandedMemorySize));
-        VSphereLogger.vsLogger(jLogger, "Finished!");
-        return true;
+	private boolean reconfigureMemory(final EnvVars env, final TaskListener listener) throws VSphereException  {
+		PrintStream jLogger = listener.getLogger();
+		String expandedMemorySize = env.expand(memorySize);
+
+		VSphereLogger.vsLogger(jLogger, "Preparing reconfigure: Memory");
+		spec.setMemoryMB(Long.valueOf(expandedMemorySize));
+		VSphereLogger.vsLogger(jLogger, "Finished!");
+		return true;
 	}
 
 	@Extension

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureNetworkAdapters.java
@@ -94,6 +94,11 @@ public class ReconfigureNetworkAdapters extends ReconfigureStep {
     }
 
     @Override
+    public void perform(@Nonnull EnvVars env, @Nonnull TaskListener listener) throws VSphereException {
+        reconfigureNetwork(env, listener);
+    }
+
+    @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
         try {
             reconfigureNetwork(run, launcher, listener);
@@ -114,27 +119,20 @@ public class ReconfigureNetworkAdapters extends ReconfigureStep {
         //TODO throw AbortException instead of returning value
     }
 
-    public boolean reconfigureNetwork(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws VSphereException  {
+    public boolean reconfigureNetwork(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws VSphereException {
+        EnvVars env = extractEnvironment(run, listener);
+
+        return reconfigureNetwork(env, listener);
+    }
+
+    private boolean reconfigureNetwork(final EnvVars env, final TaskListener listener) throws VSphereException  {
         PrintStream jLogger = listener.getLogger();
-        String expandedDeviceLabel = deviceLabel;
-        String expandedMacAddress = macAddress;
-        String expandedPortGroup = portGroup;
-        String expandedDistributedPortGroup = distributedPortGroup;
-        String expandedDistributedPortId = distributedPortId;
-        EnvVars env;
-        try {
-            env = run.getEnvironment(listener);
-        } catch (Exception e) {
-            throw new VSphereException(e);
-        }
-        if (run instanceof AbstractBuild) {
-            env.overrideAll(((AbstractBuild) run).getBuildVariables()); // Add in matrix axes..
-            expandedDeviceLabel = env.expand(deviceLabel);
-            expandedMacAddress = env.expand(macAddress);
-            expandedPortGroup = env.expand(portGroup);
-            expandedDistributedPortGroup = env.expand(distributedPortGroup);
-            expandedDistributedPortId = env.expand(distributedPortId);
-        }
+        String expandedDeviceLabel = env.expand(deviceLabel);
+        String expandedMacAddress = env.expand(macAddress);
+        String expandedPortGroup = env.expand(portGroup);
+        String expandedDistributedPortGroup = env.expand(distributedPortGroup);
+        String expandedDistributedPortId = env.expand(distributedPortId);
+
         VSphereLogger.vsLogger(jLogger, "Preparing reconfigure: "+ deviceAction.getLabel() +" Network Adapter \"" + expandedDeviceLabel + "\"");
         VirtualEthernetCard vEth = null;
         if (deviceAction == DeviceAction.ADD) {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureStep.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureStep.java
@@ -69,6 +69,8 @@ public abstract class ReconfigureStep extends AbstractDescribableImpl<Reconfigur
 
     public abstract void perform(@Nonnull Run<?, ?> run, FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException;
 
+    public abstract void perform(@Nonnull EnvVars env, @Nonnull TaskListener listener) throws VSphereException;
+
     protected VirtualDevice findDeviceByLabel(VirtualDevice[] devices, String label) {
         for(VirtualDevice d : devices) {
             if(d.getDeviceInfo().getLabel().contentEquals(label)) {
@@ -76,6 +78,20 @@ public abstract class ReconfigureStep extends AbstractDescribableImpl<Reconfigur
             }
         }
         return null;
+    }
+
+    protected EnvVars extractEnvironment(final Run<?, ?> run, final TaskListener listener) throws VSphereException  {
+        try {
+            EnvVars env = run.getEnvironment(listener);
+
+            if (run instanceof AbstractBuild) {
+                env.overrideAll(((AbstractBuild) run).getBuildVariables()); // Add in matrix axes..
+            }
+
+            return env;
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
     }
 
 	public static abstract class ReconfigureStepDescriptor extends Descriptor<ReconfigureStep> {

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -125,6 +125,11 @@
                 <f:repeatableHeteroProperty field="nodeProperties" oneEach="true" hasHeader="true"
                                             addCaption="Add Node Property" deleteCaption="Delete Node Property"/>
             </f:entry>
+
+            <f:entry title="Reconfigure VM" help="${descriptor.getHelpFile('reconfigureSteps')}">
+                <f:repeatableHeteroProperty field="reconfigureSteps" oneEach="true" hasHeader="true"
+                                            addCaption="Add Modification" deleteCaption="Delete Modification"/>
+            </f:entry>
         </f:advanced>
 
         <f:entry title="">

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-reconfigureSteps.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-reconfigureSteps.html
@@ -1,0 +1,3 @@
+<div>
+    Reconfigure the virtual machine hardware.  Allows adjusting RAM, CPU, etc.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -317,7 +317,7 @@ public class CloudProvisioningAlgorithmTest {
     private static vSphereCloudSlaveTemplate stubTemplate(String prefix, int templateInstanceCap) {
         return new vSphereCloudSlaveTemplate(prefix, "", null, null, false, null, null, null, null, null, null, templateInstanceCap, 1,
                 null, null, null, false, false, 0, 0, false, null, null, null, new JNLPLauncher(),
-                RetentionStrategy.NOOP, null, null);
+                RetentionStrategy.NOOP, null, null, null);
     }
 
     private static String toHexString(byte[] bytes) {

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
@@ -31,6 +31,7 @@ import org.jenkinsci.plugins.vSphereCloud;
 import org.jenkinsci.plugins.vSphereCloudSlaveTemplate;
 import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
 import org.jenkinsci.plugins.vsphere.VSphereGuestInfoProperty;
+import org.jenkinsci.plugins.vsphere.builders.ReconfigureStep;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -491,7 +492,7 @@ public class CloudProvisioningStateTest {
                 null, "snapshotName", false, "cluster", "resourcePool", "datastore", "folder", "customizationSpec", "templateDescription", 0, 1, "remoteFS",
                 "", Mode.NORMAL, false, false, 0, 0, false, "targetResourcePool", "targetHost", null,
                 new JNLPLauncher(), RetentionStrategy.NOOP, Collections.<NodeProperty<?>> emptyList(),
-                Collections.<VSphereGuestInfoProperty> emptyList());
+                Collections.<VSphereGuestInfoProperty> emptyList(), Collections.emptyList());
         stubVSphereCloudTemplates.add(template);
         final List<vSphereCloudSlaveTemplate> templates = new ArrayList<vSphereCloudSlaveTemplate>();
         templates.add(template);

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code.yml
@@ -26,6 +26,12 @@ jenkins:
             masterImageName: "windows-server-2019"
             mode: EXCLUSIVE
             numberOfExecutors: 1
+            reconfigureSteps:
+              - reconfigureMemory:
+                  memorySize: "8192"
+              - reconfigureCpu:
+                  coresPerSocket: "4"
+                  cpuCores: "8"
             remoteFS: "C:/jenkins"
             resourcePool: "Resources"
             retentionStrategy:

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
@@ -20,6 +20,12 @@
       masterImageName: "windows-server-2019"
       mode: EXCLUSIVE
       numberOfExecutors: 1
+      reconfigureSteps:
+      - reconfigureMemory:
+          memorySize: "8192"
+      - reconfigureCpu:
+          coresPerSocket: "4"
+          cpuCores: "8"
       remoteFS: "C:/jenkins"
       resourcePool: "Resources"
       retentionStrategy:


### PR DESCRIPTION
It is common practice to deploy a VM image under multiple labels with different
hardware capabilities, such that jobs can use an appropriately sized VM.  In
order to do so with this plugin, it was previously necessary to maintain
multiple vSphere templates.

This commit adapts the existing ReconfigureStep pipeline support for use with
templated VMs.  It is now possible to modify the VM (CPU, memory, etc) when
defining the template.  Each VM launched is appropriately reconfigured before
being brought online.