### PR TITLE
Add nodes pre-provisioning

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -202,6 +202,9 @@ public class vSphereCloud extends Cloud {
             }
         }
     }
+    public ConcurrentHashMap<String, String> getCurrentOnlineSlaves() {
+        return currentOnline;
+    }
 
     public int getMaxOnlineSlaves() {
         return maxOnlineSlaves;
@@ -215,7 +218,7 @@ public class vSphereCloud extends Cloud {
         return this.templates;
     }
 
-    private vSphereCloudSlaveTemplate getTemplateForVM(final String vmName) {
+    public vSphereCloudSlaveTemplate getTemplateForVM(final String vmName) {
         if (this.templates == null || vmName == null)
             return null;
         for (final vSphereCloudSlaveTemplate t : this.templates) {

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
@@ -133,6 +133,11 @@ public class vSphereCloudSlave extends AbstractCloudSlave {
         return LimitedTestRunCount;
     }
 
+    public vSphereCloudSlaveTemplate getTemplate() {
+        vSphereCloud cloud = findOurVsInstance();
+        return cloud.getTemplateForVM(getVmName());
+    }
+
     public boolean isLaunchSupportForced() {
         return ((vSphereCloudLauncher) getLauncher()).getOverrideLaunchSupported() == Boolean.TRUE;
     }

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveComputer.java
@@ -2,7 +2,10 @@ package org.jenkinsci.plugins;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 
 import com.vmware.vim25.VirtualHardware;
@@ -14,8 +17,10 @@ import com.vmware.vim25.VirtualMachineToolsStatus;
 import com.vmware.vim25.mo.ManagedEntity;
 import com.vmware.vim25.mo.VirtualMachine;
 
+import hudson.model.Computer;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
+import jenkins.model.Jenkins;
 
 public class vSphereCloudSlaveComputer extends AbstractCloudComputer {
     private final vSphereCloudSlave vSlave;
@@ -75,6 +80,18 @@ public class vSphereCloudSlaveComputer extends AbstractCloudComputer {
 
     public String getVmInformationError() {
         return getVMInformation().errorEncounteredWhenDataWasRead;
+    }
+
+    /**
+     * Get all computers.
+     */
+    public static @Nonnull List<vSphereCloudSlaveComputer> getAll() {
+        ArrayList<vSphereCloudSlaveComputer> out = new ArrayList<>();
+        for (final Computer c : Jenkins.get().getComputers()) {
+            if (!(c instanceof vSphereCloudSlaveComputer)) continue;
+            out.add((vSphereCloudSlaveComputer) c);
+        }
+        return out;
     }
 
     /** 10 seconds */

--- a/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
@@ -65,6 +65,10 @@ public class RunOnceCloudRetentionStrategy extends CloudRetentionStrategy implem
         if (c.isIdle() && !disabled) {
             final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
             if (idleMilliseconds > TimeUnit.MINUTES.toMillis(idleMinutes)) {
+                if (VSphereNodeReconcileWork.shouldNodeBeRetained(c)) {
+                    LOGGER.log(Level.FINE, "Keeping {0} to meet minimum requirements", c.getName());
+                    return 1;
+                }
                 LOGGER.log(
                         Level.FINE,
                         "Disconnecting {0} because it has been idle for more than {1} minutes (has been idle for {2}ms)",

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java
@@ -5,14 +5,25 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.util.concurrent.TimeUnit.*;
+import javax.annotation.concurrent.GuardedBy;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class VSphereCloudRetentionStrategy extends CloudRetentionStrategy {
+
+    private static final Logger LOGGER = Logger.getLogger(VSphereCloudRetentionStrategy.class.getName());
 
     private final int idleMinutes;
 
@@ -24,6 +35,29 @@ public class VSphereCloudRetentionStrategy extends CloudRetentionStrategy {
 
     public int getIdleMinutes() {
         return idleMinutes;
+    }
+
+    @Override
+    @GuardedBy("hudson.model.Queue.lock")
+    public long check(final AbstractCloudComputer c) {
+        final AbstractCloudSlave computerNode = c.getNode();
+        if (c.isIdle() && !disabled && computerNode != null) {
+            final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
+            if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
+                if (VSphereNodeReconcileWork.shouldNodeBeRetained(c)) {
+                    LOGGER.log(Level.FINE, "Keeping {0} to meet minimum requirements", c.getName());
+                    return 1;
+                }
+                LOGGER.log(Level.INFO, "Disconnecting {0}", c.getName());
+                try {
+                    computerNode.terminate();
+                } catch (InterruptedException | IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to terminate {0}. Exception: {1}",
+                    new Object[] { c.getName(), e});
+                }
+            }
+        }
+        return 1;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereNodeReconcileWork.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereNodeReconcileWork.java
@@ -1,0 +1,119 @@
+package org.jenkinsci.plugins.vsphere;
+
+import hudson.Extension;
+import hudson.Functions;
+import hudson.model.TaskListener;
+import hudson.model.AsyncPeriodicWork;
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
+import hudson.slaves.Cloud;
+import hudson.model.Label;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.vSphereCloud;
+import org.jenkinsci.plugins.vSphereCloudSlave;
+import org.jenkinsci.plugins.vSphereCloudSlaveComputer;
+import org.jenkinsci.plugins.vSphereCloudSlaveTemplate;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * A {@link AsyncPeriodicWork} that reconciles nodes to meet template values.
+ * <p>
+ * The async work will check the number of deployed nodes and provision (or
+ * delete) additional ones to meet template values. The check is happening every
+ * 2 minutes.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public final class VSphereNodeReconcileWork extends AsyncPeriodicWork {
+    private static final Logger LOGGER = Logger.getLogger(VSphereNodeReconcileWork.class.getName());
+
+    public VSphereNodeReconcileWork() {
+        super("Vsphere nodes reconciliation");
+    }
+
+    @Override
+    public long getRecurrencePeriod() {
+        return Functions.getIsUnitTest() ? Long.MAX_VALUE : MIN * 2;
+    }
+
+    @Override
+    public void execute(TaskListener listener) {
+        for (Cloud cloud : Jenkins.getActiveInstance().clouds) {
+            if (!(cloud instanceof vSphereCloud)) continue;
+            for (vSphereCloudSlaveTemplate template : ((vSphereCloud) cloud).getTemplates()) {
+                String templateLabel = template.getLabelString();
+                Label label = Label.get(templateLabel);
+
+                int instancesMin = template.getInstancesMin();
+                List<vSphereCloudSlaveComputer> idleNodes = template.getIdleNodes();
+                List<vSphereCloudSlaveComputer> runningNodes = template.getOnlineNodes();
+                List<vSphereCloudSlaveComputer> reusableBusyNodes = template.getBusyReusableNodes();
+                // Get max number of nodes that could be provisioned
+                int globalMaxNodes = ((vSphereCloud) cloud).getInstanceCap();
+                int templateMaxNodes = template.getTemplateInstanceCap();
+                int maxNodes = Math.min(globalMaxNodes, templateMaxNodes);
+
+                // if maxNumber is lower than instancesMin, we have to ignore instancesMin
+                int toProvision = Math.min(instancesMin - (reusableBusyNodes.size() + idleNodes.size()),
+                        maxNodes - runningNodes.size());
+                if (toProvision > 0) {
+                    // provision desired number of nodes for this label
+                    LOGGER.log(Level.INFO, "Pre-creating {0} instance(s) for template {1} in cloud {3}",
+                            new Object[] { toProvision, templateLabel, cloud.name });
+                    try {
+                        cloud.provision(label, toProvision);
+                    } catch (Throwable ex) {
+                        LOGGER.log(Level.SEVERE, "Failed to pre-create instance from template {0}. Exception: {1}",
+                                new Object[] { templateLabel, ex });
+                    }
+                } else if (toProvision < 0) {
+                    int toDelete = Math.min(idleNodes.size(), Math.abs(toProvision));
+                    for (int i = 0; i < toDelete; i++) {
+                        AbstractCloudSlave node = idleNodes.get(i).getNode();
+                        if (node == null) continue;
+                        LOGGER.log(Level.INFO, "Found excessive instance. Terminating {0} node {1}.",
+                                new Object[] { idleNodes.get(i).getName(), node });
+                        try {
+                            node.terminate();
+                        } catch (InterruptedException | IOException e) {
+                            LOGGER.log(Level.WARNING, e.getMessage());
+                            // try to delete it later
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Should a node be retained to meet the minimum instances constraint?
+     */
+    @SuppressWarnings("rawtypes")
+    public static boolean shouldNodeBeRetained(AbstractCloudComputer c) {
+        // Checks only idle nodes
+        vSphereCloudSlave node = (vSphereCloudSlave) c.getNode();
+        if (node == null) return false;
+        vSphereCloudSlaveTemplate nodeTemplate = node.getTemplate();
+        // nodeTemplate might be null if the template was manually deleted from a cloud
+        if (nodeTemplate == null) return false;
+        int instancesMin = nodeTemplate.getInstancesMin();
+        if (instancesMin > 0) {
+            int maxNodes = Math.min(nodeTemplate.getTemplateInstanceCap(), nodeTemplate.getParent().getInstanceCap());
+            int runningNodesTotal = nodeTemplate.getOnlineNodes().size();
+            int idleNodesTotal = nodeTemplate.getIdleNodes().size();
+            int reusableBusyNodesTotal = nodeTemplate.getBusyReusableNodes().size();
+            if ((instancesMin >= (idleNodesTotal + reusableBusyNodesTotal - 1)) && (runningNodesTotal <= maxNodes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -54,6 +54,10 @@
                 <f:textbox clazz="required number" default="0"/>
             </f:entry>
 
+            <f:entry title="${%Instances Min}" field="instancesMin" description="The number of instances to be pre-provisioned.">
+                <f:textbox clazz="required number" default="0"/>
+            </f:entry>
+
             <f:entry title="${%# of Executors}" field="numberOfExecutors">
                 <f:textbox clazz="required positive-number" default="1"/>
             </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningAlgorithmTest.java
@@ -316,7 +316,7 @@ public class CloudProvisioningAlgorithmTest {
 
     private static vSphereCloudSlaveTemplate stubTemplate(String prefix, int templateInstanceCap) {
         return new vSphereCloudSlaveTemplate(prefix, "", null, null, false, null, null, null, null, null, null, templateInstanceCap, 1,
-                null, null, null, false, false, 0, 0, false, null, null, null, new JNLPLauncher(),
+                null, null, null, false, false, 0, 0, false, null, null, 0, null, new JNLPLauncher(),
                 RetentionStrategy.NOOP, null, null);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/CloudProvisioningStateTest.java
@@ -489,7 +489,7 @@ public class CloudProvisioningStateTest {
         final String cloneNamePrefix = "prefix" + recordNumber;
         final vSphereCloudSlaveTemplate template = new vSphereCloudSlaveTemplate(cloneNamePrefix, "masterImageName",
                 null, "snapshotName", false, "cluster", "resourcePool", "datastore", "folder", "customizationSpec", "templateDescription", 0, 1, "remoteFS",
-                "", Mode.NORMAL, false, false, 0, 0, false, "targetResourcePool", "targetHost", null,
+                "", Mode.NORMAL, false, false, 0, 0, false, "targetResourcePool", "targetHost", 0, null,
                 new JNLPLauncher(), RetentionStrategy.NOOP, Collections.<NodeProperty<?>> emptyList(),
                 Collections.<VSphereGuestInfoProperty> emptyList());
         stubVSphereCloudTemplates.add(template);

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
@@ -61,6 +61,7 @@ public class ConfigurationAsCodeTest {
         assertThat(template.getTemplateInstanceCap(), is(5));
         assertThat(template.getUseSnapshot(), is(true));
         assertThat(template.getWaitForVMTools(), is(true));
+        assertThat(template.getInstancesMin(), is(3));
         List<? extends VSphereGuestInfoProperty> guestInfoProperties = template.getGuestInfoProperties();
         assertThat(guestInfoProperties, hasSize(1));
         VSphereGuestInfoProperty guestInfoProperty = guestInfoProperties.get(0);

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code.yml
@@ -16,6 +16,7 @@ jenkins:
               # ^ escapes the secret
               - name: "JENKINS_URL"
                 value: "^${JENKINS_URL}"
+            instancesMin: 3
             labelString: "windows vsphere"
             launchDelay: 60
             launcher:

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
@@ -10,6 +10,7 @@
       guestInfoProperties:
       - name: "JENKINS_URL"
         value: "^${JENKINS_URL}"
+      instancesMin: 3
       labelString: "windows vsphere"
       launchDelay: 60
       launcher:


### PR DESCRIPTION
In order to have instances at the ready at all times and
thus speed up CI runs because instance provisioning is done
upfront, add a mechanism and the related parameter to configure
a minimum number of instances that must be ready at all times.

Also add a mechanism to reconcile total number of nodes
based on template/cloud capacity

There is similar functionality presented in openstack cloud plugin:
https://github.com/jenkinsci/openstack-cloud-plugin/blob/master/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsPreCreationThread.java