### PR TITLE
[JENKINS-66301] Prepare vSphere for core Guava upgrade

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/PowerOn.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/PowerOn.java
@@ -16,7 +16,6 @@ package org.jenkinsci.plugins.vsphere.builders;
 
 import static org.jenkinsci.plugins.vsphere.tools.PermissionUtils.throwUnlessUserHasPermissionToConfigureJob;
 
-import com.google.common.base.Stopwatch;
 import com.vmware.vim25.mo.VirtualMachine;
 import hudson.*;
 import hudson.model.*;
@@ -96,9 +95,9 @@ public class PowerOn extends VSphereBuildStep {
 			expandedVm = env.expand(vm);
 		}
 
-        Stopwatch stopwatch = new Stopwatch().start();
+        long startTimeNanos = System.nanoTime();
         vsphere.startVm(expandedVm, timeoutInSeconds);
-        long elapsedTime = stopwatch.elapsedTime(TimeUnit.SECONDS);
+        long elapsedTime = TimeUnit.SECONDS.convert(System.nanoTime() - startTimeNanos, TimeUnit.NANOSECONDS);
 
         int secondsToWaitForIp = (int) (timeoutInSeconds - elapsedTime);
 
@@ -110,7 +109,6 @@ public class PowerOn extends VSphereBuildStep {
 		}
 
 		VSphereLogger.vsLogger(jLogger, "Successfully retrieved IP for \""+expandedVm+"\" : "+IP);
-        stopwatch.stop();
 
         // useful to tell user about the environment variable
         VSphereLogger.vsLogger(jLogger, "Exposing " + IP + " as environment variable VSPHERE_IP");


### PR DESCRIPTION
See [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988) and [JENKINS-66301](https://issues.jenkins.io/browse/JENKINS-66301). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.base.Stopwatch` API, which has changed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/Stopwatch.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Stopwatch.html). The following methods exist in Guava 11.0.1 but not latest:

 * `Stopwatch#elapsedMillis()`
 * `Stopwatch#elapsedTime(TimeUnit desiredUnit)`
 * `Stopwatch#toString(int significantDigits)`

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This PR migrates away from the `Stopwatch` API and uses `System#nanoTime` directly.