### PR TITLE
[JENKINS-68477] Prepare vSphere for removal of JAXB and Java 11 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.14</version>
+        <version>4.31</version>
     </parent>
 
     <artifactId>vsphere-cloud</artifactId>
@@ -61,7 +61,7 @@
         <revision>2.27</revision>
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <jenkins.version>2.190.1</jenkins.version>
+        <jenkins.version>2.263.1</jenkins.version>
         <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
@@ -69,8 +69,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.190.x</artifactId>
-                <version>16</version>
+                <artifactId>bom-2.263.x</artifactId>
+                <version>984.vb5eaac999a7e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -118,6 +118,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jaxb</artifactId>
+            <version>2.3.6-1</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins</groupId>


### PR DESCRIPTION
See [JENKINS-68477](https://issues.jenkins.io/browse/JENKINS-68477). This plugin bundles `com/vmware/vim25/ws/XmlGen.class`, `org/doublecloud/ws/util/ReflectUtil.class`, and Dom4j, all of which consume JAXB. But when running on Java 9+, JAXB is not included on the classpath by default. The only way for a plugin to have access to JAXB when running on Jenkins 2.164 or later on Java 11 is to declare a plugin-to-plugin dependency on JAXB API plugin (recommended) or to embed JAXB into its `.jpi` file. This PR does the former to ensure that vSphere Cloud always has access to JAXB on its classpath. Since JAXB API plugin requires 2.263 or newer, we bump the minimum Jenkins version accordingly. That, in turn, requires updating the plugin parent POM to 4.31 or later and the plugin BOM to a recent version. CC @pjdarton 