### PR TITLE
[JENKINS-69053] Provide a unique identifier for RunOnceCloudRetention…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/RunOnceCloudRetentionStrategy.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -175,6 +176,10 @@ public class RunOnceCloudRetentionStrategy extends CloudRetentionStrategy implem
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
+    /**
+     * JENKINS-69035: runOnceCloud is not unique. Keeping it as a legacy to not break compatibility.
+     */
+    @Symbol({"vsphereRunOnceCloud", "runOnceCloud"})
     public static final class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
         @Override
         public String getDisplayName() {

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-legacy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-legacy.yml
@@ -29,7 +29,7 @@ jenkins:
             remoteFS: "C:/jenkins"
             resourcePool: "Resources"
             retentionStrategy:
-              vsphereRunOnceCloud:
+              runOnceCloud:
                 idleMinutes: 2
             saveFailure: false
             templateInstanceCap: 5

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/expected_output.yml
@@ -23,7 +23,7 @@
       remoteFS: "C:/jenkins"
       resourcePool: "Resources"
       retentionStrategy:
-        runOnceCloud:
+        vsphereRunOnceCloud:
           idleMinutes: 2
       saveFailure: false
       templateInstanceCap: 5


### PR DESCRIPTION
…Strategy

[JENKINS-69035](https://issues.jenkins.io/browse/JENKINS-69035): add a Symbol `vsphereRunOnceCloud`, to give a unique identifier to the `RunOnceCloudRetentionStrategy` and avoid conflict without other plugin using the same name. Kept `runOnceCloud` in the list of symbols to guarantee compatibility.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue