### PR TITLE
Fix start java when JAVA_HOME contains character space

### DIFF
--- a/docs/attachments/JenkinsAgentStartup.cmd
+++ b/docs/attachments/JenkinsAgentStartup.cmd
@@ -482,7 +482,7 @@ GOTO :eof
 )
 @CALL :logMessage "INFO" "PUSHD %SLAVE_HOME%"
 @PUSHD "%SLAVE_HOME%" || EXIT /b 1
-@SET _cmdLine=%JAVA_HOME%bin\java -Djava.util.logging.config.file=jenkins-slave.logging.properties %SLAVE_JVM_ARGS% -jar slave.jar -jnlpUrl %SLAVE_JNLP_URL% %SLAVE_PARAMS%
+@SET _cmdLine="%JAVA_HOME%bin\java" -Djava.util.logging.config.file=jenkins-slave.logging.properties %SLAVE_JVM_ARGS% -jar slave.jar -jnlpUrl %SLAVE_JNLP_URL% %SLAVE_PARAMS%
 @CALL :logMessage "INFO" "%_cmdLine%"
 @%_cmdLine%
 @CALL :logMessage "INFO" "... slave has exited with code %ERRORLEVEL%"


### PR DESCRIPTION
If was used spaces in JAVA_HOME then execution failed

<!-- Please describe your pull request here. -->

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
