### PR TITLE
Adapting to jenkinsci/jenkins#7028

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>yavijava</artifactId>
             <version>6.0.05</version>
             <exclusions>
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>


### PR DESCRIPTION
As of jenkinsci/jenkins#7028 Jenkins core no longer has a managed, provided dependency on Log4j 1.x, but it delivers the same classes on the runtime classpath via `log4j-over-slf4j`. As such, this PR is needed to ensure that this plugin does not start bundling Log4j 1.x when its baseline is upgraded to one that includes jenkinsci/jenkins#7028. (Bundling Log4j 1.x would not be disastrous, but the plugin's copy would not be used because core's copy would take precedence.)

CC @pjdarton 