### PR TITLE
[JENKINS-74894] Remove workaround for JENKINS-19124

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereConnectionConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/VSphereConnectionConfig/config.groovy
@@ -12,13 +12,7 @@ f.entry(title:_("Disable SSL Check"), field:"allowUntrustedCertificate") {
 }
 
 f.entry(title:_("Credentials"), field:"credentialsId") {
-    c.select(onchange="""{
-            var self = this.targetElement ? this.targetElement : this;
-            var r = findPreviousFormItem(self,'url');
-            r.onchange(r);
-            self = null;
-            r = null;
-    }""" /* workaround for JENKINS-19124 */)
+    c.select()
 }
 
 f.validateButton(title:_("Test Connection"), progress:_("Testing..."), method:"testConnection", with:"vsHost,allowUntrustedCertificate,credentialsId")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74894

### Testing done

Went to `JENKINS/manage/cloud/create`, selected vSphere cloud. No CSP violations were detected by the CSP plugin. Inspecting the credentials select element revealed there's no inline `onchange` handler. Everything behaves the same way after `onchange` got removed. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
