### PR TITLE
vSphereCloud: add optional vCenter session keep-alive / connection pool

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -24,6 +24,7 @@ import org.jenkinsci.plugins.folder.FolderVSphereCloudProperty;
 import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
 import org.jenkinsci.plugins.vsphere.tools.*;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -60,9 +61,21 @@ public class vSphereCloud extends Cloud {
     private final int instanceCap;
     private final List<? extends vSphereCloudSlaveTemplate> templates;
 
+    /** When true, all API calls share one long-lived session via {@link VSphereConnectionPool}. */
+    private boolean useConnectionPool = false;
+    /** Seconds between pool session health checks; 0 disables health checks. */
+    private int poolHealthCheckIntervalSecs = 0;
+    /** Restart the pooled session after this many seconds (0 = never restart based on age). */
+    private int sessionMaxAgeSecs = 0;
+    /** Restart the pooled session after this many uses (0 = never restart based on uses). */
+    private int sessionMaxUses = 0;
+    /** Disconnect the pooled session after this many idle seconds (0 = keep alive indefinitely). */
+    private int poolIdleTimeoutSecs = 0;
+
     private transient int currentOnlineSlaveCount = 0;
     private transient ConcurrentHashMap<String, String> currentOnline;
     private transient CloudProvisioningState templateState;
+    private transient volatile VSphereConnectionPool connectionPool;
 
     private static final java.util.logging.Logger VSLOG = java.util.logging.Logger.getLogger("vsphere-cloud");
 
@@ -215,6 +228,77 @@ public class vSphereCloud extends Cloud {
         return this.templates;
     }
 
+    public boolean isUseConnectionPool() {
+        return useConnectionPool;
+    }
+
+    @DataBoundSetter
+    public void setUseConnectionPool(boolean useConnectionPool) {
+        this.useConnectionPool = useConnectionPool;
+        resetPool();
+    }
+
+    public int getPoolHealthCheckIntervalSecs() {
+        return poolHealthCheckIntervalSecs;
+    }
+
+    @DataBoundSetter
+    public void setPoolHealthCheckIntervalSecs(int poolHealthCheckIntervalSecs) {
+        this.poolHealthCheckIntervalSecs = poolHealthCheckIntervalSecs;
+        resetPool();
+    }
+
+    public int getSessionMaxAgeSecs() {
+        return sessionMaxAgeSecs;
+    }
+
+    @DataBoundSetter
+    public void setSessionMaxAgeSecs(int sessionMaxAgeSecs) {
+        this.sessionMaxAgeSecs = sessionMaxAgeSecs;
+        resetPool();
+    }
+
+    public int getSessionMaxUses() {
+        return sessionMaxUses;
+    }
+
+    @DataBoundSetter
+    public void setSessionMaxUses(int sessionMaxUses) {
+        this.sessionMaxUses = sessionMaxUses;
+        resetPool();
+    }
+
+    public int getPoolIdleTimeoutSecs() {
+        return poolIdleTimeoutSecs;
+    }
+
+    @DataBoundSetter
+    public void setPoolIdleTimeoutSecs(int poolIdleTimeoutSecs) {
+        this.poolIdleTimeoutSecs = poolIdleTimeoutSecs;
+        resetPool();
+    }
+
+    /** Shuts down any running pool and clears the reference so it is recreated on next use. */
+    private synchronized void resetPool() {
+        if (connectionPool != null) {
+            connectionPool.shutdown();
+            connectionPool = null;
+        }
+    }
+
+    /** Returns (lazily creating) the connection pool for this cloud instance. */
+    private synchronized VSphereConnectionPool getOrCreatePool(VSphereConnectionConfig config) {
+        if (connectionPool == null) {
+            connectionPool = new VSphereConnectionPool(
+                    config,
+                    poolHealthCheckIntervalSecs,
+                    sessionMaxAgeSecs,
+                    sessionMaxUses,
+                    poolIdleTimeoutSecs);
+        }
+        return connectionPool;
+    }
+
     private vSphereCloudSlaveTemplate getTemplateForVM(final String vmName) {
         if (this.templates == null || vmName == null)
             return null;
@@ -299,6 +383,9 @@ public class vSphereCloud extends Cloud {
             throw new VSphereException("vSphere username is not specified");
         }
 
+        if (useConnectionPool) {
+            return getOrCreatePool(connectionConfig).acquire();
+        }
         return VSphere.connect(connectionConfig);
     }
 
@@ -704,6 +791,22 @@ public class vSphereCloud extends Cloud {
         }
 
         public FormValidation doCheckInstanceCap(@QueryParameter String value) {
+            return FormValidation.validateNonNegativeInteger(value);
+        }
+
+        public FormValidation doCheckPoolHealthCheckIntervalSecs(@QueryParameter String value) {
+            return FormValidation.validateNonNegativeInteger(value);
+        }
+
+        public FormValidation doCheckSessionMaxAgeSecs(@QueryParameter String value) {
+            return FormValidation.validateNonNegativeInteger(value);
+        }
+
+        public FormValidation doCheckSessionMaxUses(@QueryParameter String value) {
+            return FormValidation.validateNonNegativeInteger(value);
+        }
+
+        public FormValidation doCheckPoolIdleTimeoutSecs(@QueryParameter String value) {
             return FormValidation.validateNonNegativeInteger(value);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -291,6 +291,7 @@ public class vSphereCloud extends Cloud {
         if (connectionPool == null) {
             connectionPool = new VSphereConnectionPool(
                     config,
+                    this,
                     poolHealthCheckIntervalSecs,
                     sessionMaxAgeSecs,
                     sessionMaxUses,

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -492,7 +492,13 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                           TaskListener taskListener)
             throws IOException, InterruptedException, VSphereException {
         if (!snapName.isEmpty()) {
-            VirtualMachineSnapshot snap = vsC.vSphereInstance().getSnapshotInTree(vm, snapName);
+            VSphere tmpVs = vsC.vSphereInstance();
+            VirtualMachineSnapshot snap;
+            try {
+                snap = tmpVs.getSnapshotInTree(vm, snapName);
+            } finally {
+                tmpVs.disconnect();
+            }
             if (snap == null) {
                 throw new IOException("Virtual Machine snapshot cannot be found");
             }

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlave.java
@@ -18,6 +18,8 @@ import hudson.util.FormValidation;
 import java.io.IOException;
 
 import org.jenkinsci.plugins.vsphere.VSphereOfflineCause;
+import org.jenkinsci.plugins.vsphere.tools.VSphere;
+import org.jenkinsci.plugins.vsphere.tools.VSphereException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -419,17 +421,22 @@ public class vSphereCloudSlave extends AbstractCloudSlave {
             throwUnlessUserHasPermissionToConfigureSlave(context);
             try {
                 vSphereCloud vsC = getSpecificvSphereCloud(vsDescription);
-                VirtualMachine vm = vsC.vSphereInstance().getVmByName(vmName);
-                if (vm == null) {
-                    return FormValidation.error("Virtual Machine was not found");
-                }
-                if (!snapName.isEmpty()) {
-                    VirtualMachineSnapshot snap = vsC.vSphereInstance().getSnapshotInTree(vm, snapName);
-                    if (snap == null) {
-                        return FormValidation.error("Virtual Machine snapshot was not found");
+                VSphere vs = vsC.vSphereInstance();
+                try {
+                    VirtualMachine vm = vs.getVmByName(vmName);
+                    if (vm == null) {
+                        return FormValidation.error("Virtual Machine was not found");
                     }
+                    if (!snapName.isEmpty()) {
+                        VirtualMachineSnapshot snap = vs.getSnapshotInTree(vm, snapName);
+                        if (snap == null) {
+                            return FormValidation.error("Virtual Machine snapshot was not found");
+                        }
+                    }
+                    return FormValidation.ok("Virtual Machine found successfully");
+                } finally {
+                    vs.disconnect();
                 }
-                return FormValidation.ok("Virtual Machine found successfully");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveComputer.java
@@ -98,8 +98,12 @@ public class vSphereCloudSlaveComputer extends AbstractCloudComputer {
                 final String ourVmName = vSlave.getVmName();
                 final vSphereCloud ourCloud = vSlave.findOurVsInstance();
                 final VSphere vSphereInstance = ourCloud.vSphereInstance();
-                final VirtualMachine ourVm = vSphereInstance.getVmByName(ourVmName);
-                vmInformation = new VMInformation(systemUptimeNow, ourVm);
+                try {
+                    final VirtualMachine ourVm = vSphereInstance.getVmByName(ourVmName);
+                    vmInformation = new VMInformation(systemUptimeNow, ourVm);
+                } finally {
+                    vSphereInstance.disconnect();
+                }
             } catch (Throwable e) {
                 vmInformation = new VMInformation(systemUptimeNow, e);
             }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -69,6 +69,12 @@ public class VSphere {
     private final String session;
     private final static Logger LOGGER = Logger.getLogger(VSphere.class.getName());
 
+    /**
+     * When true, {@link #disconnect()} is a no-op; lifecycle is managed by
+     * {@link VSphereConnectionPool}.
+     */
+    private volatile boolean pooled = false;
+
     private VSphere(@NonNull String url, boolean ignoreCert, @NonNull String user, @CheckForNull String pw) throws VSphereException {
         try {
             this.url = new URL(url);
@@ -116,15 +122,59 @@ public class VSphere {
     /**
      * Disconnect from vSphere server.
      * <p>
+     * When this instance is managed by a {@link VSphereConnectionPool} the call is
+     * silently ignored; the pool handles the actual session lifecycle.
+     * </p>
+     * <p>
      * Note: This logs any {@link Exception} it encounters - it does not pass
      * them to get to the calling method.
      * </p>
      */
     public void disconnect() {
+        if (pooled) {
+            return;
+        }
         try {
             this.getServiceInstance().getServerConnection().logout();
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Caught exception when trying to disconnect vSphere.", e);
+        }
+    }
+
+    /**
+     * Marks this instance as owned by a {@link VSphereConnectionPool} so that
+     * {@link #disconnect()} becomes a no-op for ordinary callers.
+     * Package-private — only {@link VSphereConnectionPool} should call this.
+     */
+    void markAsPooled() {
+        pooled = true;
+    }
+
+    /**
+     * Disconnects the underlying session regardless of the pooled flag.
+     * Called by {@link VSphereConnectionPool} when it actually wants to tear down
+     * the session (restart, idle timeout, shutdown).
+     * Package-private — only {@link VSphereConnectionPool} should call this.
+     */
+    void forceDisconnect() {
+        pooled = false;
+        disconnect();
+    }
+
+    /**
+     * Checks whether the current vSphere session is still alive by issuing a
+     * lightweight {@code getCurrentTime()} call.
+     *
+     * @return {@code true} if the session responds normally; {@code false} if it
+     *         has expired or the server is unreachable.
+     */
+    public boolean isSessionAlive() {
+        try {
+            getServiceInstance().currentTime();
+            return true;
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "vSphere session alive-check failed", e);
+            return false;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -163,7 +163,7 @@ public class VSphere {
 
     /**
      * Checks whether the current vSphere session is still alive by issuing a
-     * lightweight {@code getCurrentTime()} call.
+     * lightweight {@code currentTime()} call.
      *
      * @return {@code true} if the session responds normally; {@code false} if it
      *         has expired or the server is unreachable.

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
@@ -1,0 +1,236 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Maintains a single long-lived vSphere session for one {@code vSphereCloud} instance,
+ * eliminating the per-operation login/logout overhead that occurs when every API call
+ * creates and destroys its own session.
+ *
+ * <h3>Caller contract</h3>
+ * <ol>
+ *   <li>Obtain the shared connection via {@link #acquire()}.</li>
+ *   <li>Use it normally — all public {@link VSphere} methods work as usual.</li>
+ *   <li>Call {@link VSphere#disconnect()} when done.  For pooled connections this is a
+ *       no-op; the pool controls the real session lifecycle.</li>
+ * </ol>
+ *
+ * <h3>Background maintenance</h3>
+ * <ul>
+ *   <li><b>Health check</b> — if {@code healthCheckIntervalSecs > 0}, a daemon thread
+ *       periodically issues a lightweight {@code getCurrentTime()} call and reconnects
+ *       automatically on failure.</li>
+ *   <li><b>Session age limit</b> — if {@code sessionMaxAgeSecs > 0}, the session is
+ *       proactively restarted once it has been alive for that many seconds, both in the
+ *       background and on the next {@link #acquire()} call.</li>
+ *   <li><b>Use-count limit</b> — if {@code sessionMaxUses > 0}, the session is restarted
+ *       on the next {@link #acquire()} once that many acquisitions have been made.</li>
+ *   <li><b>Idle timeout</b> — if {@code idleTimeoutSecs > 0}, the session is disconnected
+ *       (and lazily reconnected on the next {@link #acquire()}) after the connection has
+ *       not been acquired for that many seconds.</li>
+ * </ul>
+ *
+ * <p>A value of {@code 0} disables the corresponding feature.
+ *
+ * <p>Thread-safe.  All mutable state is guarded by {@code this}.
+ */
+public class VSphereConnectionPool {
+
+    private static final Logger LOGGER = Logger.getLogger(VSphereConnectionPool.class.getName());
+
+    private final VSphereConnectionConfig config;
+
+    private final int healthCheckIntervalSecs;
+    private final int sessionMaxAgeSecs;
+    private final int sessionMaxUses;
+    private final int idleTimeoutSecs;
+
+    /* Guarded by this */
+    private VSphere connection;
+    private long connectionCreatedAtMs;
+    private long lastAcquiredAtMs;
+    private long useCount;
+
+    private ScheduledExecutorService scheduler;
+
+    public VSphereConnectionPool(
+            @NonNull VSphereConnectionConfig config,
+            int healthCheckIntervalSecs,
+            int sessionMaxAgeSecs,
+            int sessionMaxUses,
+            int idleTimeoutSecs) {
+        this.config = config;
+        this.healthCheckIntervalSecs = Math.max(0, healthCheckIntervalSecs);
+        this.sessionMaxAgeSecs       = Math.max(0, sessionMaxAgeSecs);
+        this.sessionMaxUses          = Math.max(0, sessionMaxUses);
+        this.idleTimeoutSecs         = Math.max(0, idleTimeoutSecs);
+        startScheduler();
+    }
+
+    /**
+     * Returns the pooled {@link VSphere} connection, creating or restarting it if
+     * necessary.  The returned instance is marked as pooled so that callers'
+     * {@link VSphere#disconnect()} calls are no-ops.
+     *
+     * @throws VSphereException if establishing the session fails.
+     */
+    public synchronized VSphere acquire() throws VSphereException {
+        ensureConnected();
+        lastAcquiredAtMs = System.currentTimeMillis();
+        useCount++;
+        connection.markAsPooled();
+        return connection;
+    }
+
+    /**
+     * Disconnects the current session (if any) and shuts down all background threads.
+     * After this call the pool must not be used.
+     */
+    public synchronized void shutdown() {
+        stopScheduler();
+        disconnectQuietly();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers (all called with this lock held unless noted)
+    // -------------------------------------------------------------------------
+
+    private void ensureConnected() throws VSphereException {
+        if (connection == null) {
+            connect();
+            return;
+        }
+        boolean ageExpired = sessionMaxAgeSecs > 0
+                && (System.currentTimeMillis() - connectionCreatedAtMs) > (long) sessionMaxAgeSecs * 1000L;
+        boolean usesExhausted = sessionMaxUses > 0 && useCount >= sessionMaxUses;
+        if (ageExpired || usesExhausted) {
+            LOGGER.info("vSphere connection pool [" + config.getVsHost() + "]: restarting session — "
+                    + (ageExpired ? "max age reached" : "max uses reached"));
+            disconnectQuietly();
+            connect();
+        }
+    }
+
+    private void connect() throws VSphereException {
+        connection = VSphere.connect(config);
+        connection.markAsPooled();
+        connectionCreatedAtMs = System.currentTimeMillis();
+        lastAcquiredAtMs      = connectionCreatedAtMs;
+        useCount              = 0;
+        LOGGER.info("vSphere connection pool [" + config.getVsHost() + "]: session established");
+    }
+
+    private void disconnectQuietly() {
+        if (connection != null) {
+            connection.forceDisconnect();
+            connection = null;
+        }
+    }
+
+    // Called from the background scheduler thread
+    private void scheduledHealthCheck() {
+        synchronized (this) {
+            if (connection == null) return;
+            if (connection.isSessionAlive()) {
+                LOGGER.fine("vSphere connection pool [" + config.getVsHost() + "]: health check OK");
+                return;
+            }
+            LOGGER.warning("vSphere connection pool [" + config.getVsHost()
+                    + "]: health check failed — reconnecting");
+            disconnectQuietly();
+            try {
+                connect();
+            } catch (VSphereException e) {
+                LOGGER.log(Level.SEVERE,
+                        "vSphere connection pool [" + config.getVsHost()
+                                + "]: reconnect after health-check failure failed", e);
+                // connection remains null; next acquire() will retry
+            }
+        }
+    }
+
+    // Called from the background scheduler thread
+    private void scheduledMaintenance() {
+        synchronized (this) {
+            if (connection == null) return;
+
+            // Proactive age-based restart (before callers run into an expired session)
+            if (sessionMaxAgeSecs > 0) {
+                long ageMs = System.currentTimeMillis() - connectionCreatedAtMs;
+                if (ageMs > (long) sessionMaxAgeSecs * 1000L) {
+                    LOGGER.info("vSphere connection pool [" + config.getVsHost()
+                            + "]: proactive reconnect — max session age reached");
+                    disconnectQuietly();
+                    try {
+                        connect();
+                    } catch (VSphereException e) {
+                        LOGGER.log(Level.SEVERE,
+                                "vSphere connection pool [" + config.getVsHost()
+                                        + "]: proactive reconnect failed", e);
+                    }
+                    return;
+                }
+            }
+
+            // Idle disconnect
+            if (idleTimeoutSecs > 0 && lastAcquiredAtMs > 0) {
+                long idleMs = System.currentTimeMillis() - lastAcquiredAtMs;
+                if (idleMs > (long) idleTimeoutSecs * 1000L) {
+                    LOGGER.info(String.format(
+                            "vSphere connection pool [%s]: disconnecting — idle for %ds (limit %ds)",
+                            config.getVsHost(), idleMs / 1000, idleTimeoutSecs));
+                    disconnectQuietly();
+                }
+            }
+        }
+    }
+
+    private void startScheduler() {
+        boolean needsScheduler = healthCheckIntervalSecs > 0
+                || idleTimeoutSecs > 0
+                || sessionMaxAgeSecs > 0;
+        if (!needsScheduler) return;
+
+        final String host = config.getVsHost();
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "vsphere-pool-" + host);
+            t.setDaemon(true);
+            return t;
+        });
+
+        if (healthCheckIntervalSecs > 0) {
+            scheduler.scheduleAtFixedRate(
+                    this::scheduledHealthCheck,
+                    healthCheckIntervalSecs, healthCheckIntervalSecs, TimeUnit.SECONDS);
+        }
+
+        if (idleTimeoutSecs > 0 || sessionMaxAgeSecs > 0) {
+            // Pick a maintenance interval that fires frequently enough to be useful
+            // but not so often that it wastes resources.
+            int maintenanceSecs = 30;
+            if (idleTimeoutSecs > 0) {
+                maintenanceSecs = Math.min(maintenanceSecs, Math.max(5, idleTimeoutSecs / 2));
+            }
+            if (sessionMaxAgeSecs > 0) {
+                maintenanceSecs = Math.min(maintenanceSecs, Math.max(5, sessionMaxAgeSecs / 4));
+            }
+            scheduler.scheduleAtFixedRate(
+                    this::scheduledMaintenance,
+                    maintenanceSecs, maintenanceSecs, TimeUnit.SECONDS);
+        }
+    }
+
+    private void stopScheduler() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            scheduler = null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
@@ -5,6 +5,7 @@ import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -27,15 +28,21 @@ import java.util.logging.Logger;
  *   <li><b>Health check</b> - if {@code healthCheckIntervalSecs > 0}, a daemon thread
  *       periodically issues a lightweight {@code currentTime()} call and reconnects
  *       automatically on failure.</li>
- *   <li><b>Session age limit</b> - if {@code sessionMaxAgeSecs > 0}, the session is
- *       proactively restarted once it has been alive for that many seconds, both in the
- *       background and on the next {@link #acquire()} call.</li>
+ *   <li><b>Session age limit</b> - if {@code sessionMaxAgeSecs > 0}, a one-shot timer is
+ *       armed for the exact moment the session reaches that age, at which point it is
+ *       proactively restarted (also re-checked defensively on the next
+ *       {@link #acquire()} call).</li>
  *   <li><b>Use-count limit</b> - if {@code sessionMaxUses > 0}, the session is restarted
  *       on the next {@link #acquire()} once that many acquisitions have been made.</li>
- *   <li><b>Idle timeout</b> - if {@code idleTimeoutSecs > 0}, the session is disconnected
- *       (and lazily reconnected on the next {@link #acquire()}) after the connection has
- *       not been acquired for that many seconds.</li>
+ *   <li><b>Idle timeout</b> - if {@code idleTimeoutSecs > 0}, a one-shot timer is armed
+ *       for the exact moment the connection has gone unused for that many seconds, at
+ *       which point it is disconnected (and lazily reconnected on the next
+ *       {@link #acquire()}). The timer is re-armed on every {@link #acquire()}.</li>
  * </ul>
+ *
+ * <p>Session age and idle timeout are enforced by dedicated one-shot alarms rather than
+ * periodic polling, so they fire at (approximately) the exact configured deadline instead
+ * of some time after it.
  *
  * <p>A value of {@code 0} disables the corresponding feature.
  *
@@ -57,6 +64,8 @@ public class VSphereConnectionPool {
     private long connectionCreatedAtMs;
     private long lastAcquiredAtMs;
     private long useCount;
+    private ScheduledFuture<?> ageExpiryFuture;
+    private ScheduledFuture<?> idleExpiryFuture;
 
     private ScheduledExecutorService scheduler;
 
@@ -86,6 +95,7 @@ public class VSphereConnectionPool {
         lastAcquiredAtMs = System.currentTimeMillis();
         useCount++;
         connection.markAsPooled();
+        scheduleIdleExpiry();
         return connection;
     }
 
@@ -125,6 +135,68 @@ public class VSphereConnectionPool {
         lastAcquiredAtMs      = connectionCreatedAtMs;
         useCount              = 0;
         LOGGER.info("vSphere connection pool [" + config.getVsHost() + "]: session established");
+        scheduleAgeExpiry();
+        scheduleIdleExpiry();
+    }
+
+    // Arms (or re-arms) a one-shot timer for the exact moment the current session
+    // reaches sessionMaxAgeSecs. Called with this locked.
+    private void scheduleAgeExpiry() {
+        if (ageExpiryFuture != null) {
+            ageExpiryFuture.cancel(false);
+            ageExpiryFuture = null;
+        }
+        if (sessionMaxAgeSecs <= 0 || scheduler == null) {
+            return;
+        }
+        ageExpiryFuture = scheduler.schedule(this::onAgeExpired, sessionMaxAgeSecs, TimeUnit.SECONDS);
+    }
+
+    // Arms (or re-arms) a one-shot timer for the exact moment the connection will have
+    // been idle (unacquired) for idleTimeoutSecs. Called with this locked.
+    private void scheduleIdleExpiry() {
+        if (idleExpiryFuture != null) {
+            idleExpiryFuture.cancel(false);
+            idleExpiryFuture = null;
+        }
+        if (idleTimeoutSecs <= 0 || scheduler == null) {
+            return;
+        }
+        idleExpiryFuture = scheduler.schedule(this::onIdleExpired, idleTimeoutSecs, TimeUnit.SECONDS);
+    }
+
+    // Called from the background scheduler thread, at the exact session-age deadline
+    private void onAgeExpired() {
+        synchronized (this) {
+            if (connection == null) return;
+            LOGGER.info("vSphere connection pool [" + config.getVsHost()
+                    + "]: proactive reconnect - max session age reached");
+            disconnectQuietly();
+            try {
+                connect();
+            } catch (VSphereException e) {
+                LOGGER.log(Level.SEVERE,
+                        "vSphere connection pool [" + config.getVsHost()
+                                + "]: proactive reconnect failed", e);
+                // connection remains null; next acquire() will retry
+            }
+        }
+    }
+
+    // Called from the background scheduler thread, at the exact idle-timeout deadline
+    private void onIdleExpired() {
+        synchronized (this) {
+            if (connection == null) return;
+            long idleMs = System.currentTimeMillis() - lastAcquiredAtMs;
+            LOGGER.info(String.format(
+                    "vSphere connection pool [%s]: disconnecting - idle for %ds (limit %ds)",
+                    config.getVsHost(), idleMs / 1000, idleTimeoutSecs));
+            disconnectQuietly();
+            if (ageExpiryFuture != null) {
+                ageExpiryFuture.cancel(false);
+                ageExpiryFuture = null;
+            }
+        }
     }
 
     private void disconnectQuietly() {
@@ -156,42 +228,6 @@ public class VSphereConnectionPool {
         }
     }
 
-    // Called from the background scheduler thread
-    private void scheduledMaintenance() {
-        synchronized (this) {
-            if (connection == null) return;
-
-            // Proactive age-based restart (before callers run into an expired session)
-            if (sessionMaxAgeSecs > 0) {
-                long ageMs = System.currentTimeMillis() - connectionCreatedAtMs;
-                if (ageMs > (long) sessionMaxAgeSecs * 1000L) {
-                    LOGGER.info("vSphere connection pool [" + config.getVsHost()
-                            + "]: proactive reconnect - max session age reached");
-                    disconnectQuietly();
-                    try {
-                        connect();
-                    } catch (VSphereException e) {
-                        LOGGER.log(Level.SEVERE,
-                                "vSphere connection pool [" + config.getVsHost()
-                                        + "]: proactive reconnect failed", e);
-                    }
-                    return;
-                }
-            }
-
-            // Idle disconnect
-            if (idleTimeoutSecs > 0 && lastAcquiredAtMs > 0) {
-                long idleMs = System.currentTimeMillis() - lastAcquiredAtMs;
-                if (idleMs > (long) idleTimeoutSecs * 1000L) {
-                    LOGGER.info(String.format(
-                            "vSphere connection pool [%s]: disconnecting - idle for %ds (limit %ds)",
-                            config.getVsHost(), idleMs / 1000, idleTimeoutSecs));
-                    disconnectQuietly();
-                }
-            }
-        }
-    }
-
     private void startScheduler() {
         boolean needsScheduler = healthCheckIntervalSecs > 0
                 || idleTimeoutSecs > 0
@@ -211,20 +247,8 @@ public class VSphereConnectionPool {
                     healthCheckIntervalSecs, healthCheckIntervalSecs, TimeUnit.SECONDS);
         }
 
-        if (idleTimeoutSecs > 0 || sessionMaxAgeSecs > 0) {
-            // Pick a maintenance interval that fires frequently enough to be useful
-            // but not so often that it wastes resources.
-            int maintenanceSecs = 30;
-            if (idleTimeoutSecs > 0) {
-                maintenanceSecs = Math.min(maintenanceSecs, Math.max(5, idleTimeoutSecs / 2));
-            }
-            if (sessionMaxAgeSecs > 0) {
-                maintenanceSecs = Math.min(maintenanceSecs, Math.max(5, sessionMaxAgeSecs / 4));
-            }
-            scheduler.scheduleAtFixedRate(
-                    this::scheduledMaintenance,
-                    maintenanceSecs, maintenanceSecs, TimeUnit.SECONDS);
-        }
+        // Age-expiry and idle-expiry are armed as exact one-shot alarms from connect()
+        // and acquire() respectively, once a connection actually exists.
     }
 
     private void stopScheduler() {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
@@ -35,7 +35,12 @@ import java.util.logging.Logger;
  *   <li><b>Session age limit</b> - if {@code sessionMaxAgeSecs > 0}, a one-shot timer is
  *       armed for the exact moment the session reaches that age, at which point it is
  *       proactively restarted (also re-checked defensively on the next
- *       {@link #acquire()} call).</li>
+ *       {@link #acquire()} call) - unless {@code idleTimeoutSecs > 0} and no consumer has
+ *       acquired the session since it was established, in which case it is disconnected
+ *       instead of restarted, deferring to the idle policy. Without this, a
+ *       {@code sessionMaxAgeSecs} smaller than {@code idleTimeoutSecs} would otherwise
+ *       reconnect an unused session forever, since each reconnect also resets the idle
+ *       clock and the idle timeout would never get a chance to win.</li>
  *   <li><b>Use-count limit</b> - if {@code sessionMaxUses > 0}, the session is restarted
  *       on the next {@link #acquire()} once that many acquisitions have been made.</li>
  *   <li><b>Idle timeout</b> - if {@code idleTimeoutSecs > 0}, a one-shot timer is armed
@@ -221,6 +226,24 @@ public class VSphereConnectionPool {
     private void onAgeExpired() {
         synchronized (this) {
             if (connection == null) return;
+            if (idleTimeoutSecs > 0 && useCount == 0) {
+                // No consumer has acquired this session since it was established (only
+                // background health-checks, if any, run without going through
+                // acquire()). Reconnecting here would just start a brand new session
+                // that is equally unused and would reset the idle clock too, looping
+                // forever whenever sessionMaxAgeSecs < idleTimeoutSecs. Defer to the
+                // idle policy instead: disconnect and let the next real acquire() (if
+                // any) lazily reconnect.
+                LOGGER.info("vSphere connection pool [" + config.getVsHost()
+                        + "]: max session age reached, but session has not been used since "
+                        + "it was established - disconnecting instead of reconnecting (idle policy applies)");
+                disconnectQuietly();
+                if (idleExpiryFuture != null) {
+                    idleExpiryFuture.cancel(false);
+                    idleExpiryFuture = null;
+                }
+                return;
+            }
             LOGGER.info("vSphere connection pool [" + config.getVsHost()
                     + "]: proactive reconnect - max session age reached");
             disconnectQuietly();

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
@@ -1,8 +1,12 @@
 package org.jenkinsci.plugins.vsphere.tools;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
 
+import java.lang.ref.WeakReference;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -53,6 +57,7 @@ public class VSphereConnectionPool {
     private static final Logger LOGGER = Logger.getLogger(VSphereConnectionPool.class.getName());
 
     private final VSphereConnectionConfig config;
+    private final WeakReference<Cloud> owner;
 
     private final int healthCheckIntervalSecs;
     private final int sessionMaxAgeSecs;
@@ -75,12 +80,31 @@ public class VSphereConnectionPool {
             int sessionMaxAgeSecs,
             int sessionMaxUses,
             int idleTimeoutSecs) {
+        this(config, null, healthCheckIntervalSecs, sessionMaxAgeSecs, sessionMaxUses, idleTimeoutSecs);
+    }
+
+    /**
+     * @param owner the {@link Cloud} this pool belongs to, used only so that
+     *              {@link VSphereConnectionPoolRegistry} can detect and shut down pools
+     *              left behind by a cloud instance that was replaced by reconfiguration
+     *              (e.g. saving the Jenkins global config). May be {@code null} (e.g. in
+     *              tests), in which case this pool is never auto-reaped as an orphan.
+     */
+    public VSphereConnectionPool(
+            @NonNull VSphereConnectionConfig config,
+            @CheckForNull Cloud owner,
+            int healthCheckIntervalSecs,
+            int sessionMaxAgeSecs,
+            int sessionMaxUses,
+            int idleTimeoutSecs) {
         this.config = config;
+        this.owner = owner == null ? null : new WeakReference<>(owner);
         this.healthCheckIntervalSecs = Math.max(0, healthCheckIntervalSecs);
         this.sessionMaxAgeSecs       = Math.max(0, sessionMaxAgeSecs);
         this.sessionMaxUses          = Math.max(0, sessionMaxUses);
         this.idleTimeoutSecs         = Math.max(0, idleTimeoutSecs);
         startScheduler();
+        VSphereConnectionPoolRegistry.register(this);
     }
 
     /**
@@ -104,8 +128,36 @@ public class VSphereConnectionPool {
      * After this call the pool must not be used.
      */
     public synchronized void shutdown() {
+        VSphereConnectionPoolRegistry.unregister(this);
         stopScheduler();
         disconnectQuietly();
+    }
+
+    /**
+     * Returns {@code true} if the {@link Cloud} this pool was created for is no longer
+     * present in {@code Jenkins.get().clouds} (e.g. it was replaced by a reconfiguration
+     * of the global/folder cloud config), meaning this pool's background thread and any
+     * session it still holds are now orphaned.  A pool created without an owner (e.g. in
+     * tests) is never considered orphaned.
+     */
+    boolean isOrphaned() {
+        if (owner == null) {
+            return false;
+        }
+        Cloud cloud = owner.get();
+        if (cloud == null) {
+            return true;
+        }
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return false;
+        }
+        for (Cloud live : jenkins.clouds) {
+            if (live == cloud) {
+                return false;
+            }
+        }
+        return true;
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
@@ -111,7 +111,7 @@ public class VSphereConnectionPool {
                 && (System.currentTimeMillis() - connectionCreatedAtMs) > (long) sessionMaxAgeSecs * 1000L;
         boolean usesExhausted = sessionMaxUses > 0 && useCount >= sessionMaxUses;
         if (ageExpired || usesExhausted) {
-            LOGGER.info("vSphere connection pool [" + config.getVsHost() + "]: restarting session — "
+            LOGGER.info("vSphere connection pool [" + config.getVsHost() + "]: restarting session - "
                     + (ageExpired ? "max age reached" : "max uses reached"));
             disconnectQuietly();
             connect();
@@ -143,7 +143,7 @@ public class VSphereConnectionPool {
                 return;
             }
             LOGGER.warning("vSphere connection pool [" + config.getVsHost()
-                    + "]: health check failed — reconnecting");
+                    + "]: health check failed - reconnecting");
             disconnectQuietly();
             try {
                 connect();
@@ -166,7 +166,7 @@ public class VSphereConnectionPool {
                 long ageMs = System.currentTimeMillis() - connectionCreatedAtMs;
                 if (ageMs > (long) sessionMaxAgeSecs * 1000L) {
                     LOGGER.info("vSphere connection pool [" + config.getVsHost()
-                            + "]: proactive reconnect — max session age reached");
+                            + "]: proactive reconnect - max session age reached");
                     disconnectQuietly();
                     try {
                         connect();
@@ -184,7 +184,7 @@ public class VSphereConnectionPool {
                 long idleMs = System.currentTimeMillis() - lastAcquiredAtMs;
                 if (idleMs > (long) idleTimeoutSecs * 1000L) {
                     LOGGER.info(String.format(
-                            "vSphere connection pool [%s]: disconnecting — idle for %ds (limit %ds)",
+                            "vSphere connection pool [%s]: disconnecting - idle for %ds (limit %ds)",
                             config.getVsHost(), idleMs / 1000, idleTimeoutSecs));
                     disconnectQuietly();
                 }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPool.java
@@ -14,25 +14,25 @@ import java.util.logging.Logger;
  * eliminating the per-operation login/logout overhead that occurs when every API call
  * creates and destroys its own session.
  *
- * <h3>Caller contract</h3>
+ * <p><b>Caller contract:</b></p>
  * <ol>
  *   <li>Obtain the shared connection via {@link #acquire()}.</li>
- *   <li>Use it normally — all public {@link VSphere} methods work as usual.</li>
+ *   <li>Use it normally - all public {@link VSphere} methods work as usual.</li>
  *   <li>Call {@link VSphere#disconnect()} when done.  For pooled connections this is a
  *       no-op; the pool controls the real session lifecycle.</li>
  * </ol>
  *
- * <h3>Background maintenance</h3>
+ * <p><b>Background maintenance:</b></p>
  * <ul>
- *   <li><b>Health check</b> — if {@code healthCheckIntervalSecs > 0}, a daemon thread
- *       periodically issues a lightweight {@code getCurrentTime()} call and reconnects
+ *   <li><b>Health check</b> - if {@code healthCheckIntervalSecs > 0}, a daemon thread
+ *       periodically issues a lightweight {@code currentTime()} call and reconnects
  *       automatically on failure.</li>
- *   <li><b>Session age limit</b> — if {@code sessionMaxAgeSecs > 0}, the session is
+ *   <li><b>Session age limit</b> - if {@code sessionMaxAgeSecs > 0}, the session is
  *       proactively restarted once it has been alive for that many seconds, both in the
  *       background and on the next {@link #acquire()} call.</li>
- *   <li><b>Use-count limit</b> — if {@code sessionMaxUses > 0}, the session is restarted
+ *   <li><b>Use-count limit</b> - if {@code sessionMaxUses > 0}, the session is restarted
  *       on the next {@link #acquire()} once that many acquisitions have been made.</li>
- *   <li><b>Idle timeout</b> — if {@code idleTimeoutSecs > 0}, the session is disconnected
+ *   <li><b>Idle timeout</b> - if {@code idleTimeoutSecs > 0}, the session is disconnected
  *       (and lazily reconnected on the next {@link #acquire()}) after the connection has
  *       not been acquired for that many seconds.</li>
  * </ul>

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolLifecycleListener.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolLifecycleListener.java
@@ -2,18 +2,25 @@ package org.jenkinsci.plugins.vsphere.tools;
 
 import hudson.Extension;
 import hudson.XmlFile;
+import hudson.init.Terminator;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 
 /**
- * Keeps {@link VSphereConnectionPool} instances honest across an event that Jenkins core
- * has no dedicated "cloud replaced/removed" hook for: saving the Jenkins configuration
- * (e.g. the "Manage Jenkins &gt; Clouds" form, or a JCasC reload) replaces every
- * reconfigured {@code vSphereCloud} with a brand new instance; the old instance - and the
- * pool/background-thread/vCenter session it may still own - is simply dropped by Jenkins
- * core with no notification. Without this listener that old pool keeps running under its
- * previous settings indefinitely, which is very confusing to observe (it looks like
- * configuration changes are being ignored).
+ * Keeps {@link VSphereConnectionPool} instances honest across two events that Jenkins
+ * core has no dedicated "cloud replaced/removed" hook for:
+ *
+ * <ul>
+ *   <li>Saving the Jenkins configuration (e.g. the "Manage Jenkins &gt; Clouds" form, or
+ *       a JCasC reload) replaces every reconfigured {@code vSphereCloud} with a brand new
+ *       instance; the old instance - and the pool/background-thread/vCenter session it
+ *       may still own - is simply dropped by Jenkins core with no notification.  Without
+ *       this listener that old pool keeps running under its previous settings
+ *       indefinitely, which is very confusing to observe (it looks like configuration
+ *       changes are being ignored).</li>
+ *   <li>Jenkins shutting down does not otherwise give pooled vCenter sessions a chance to
+ *       log out.</li>
+ * </ul>
  */
 public final class VSphereConnectionPoolLifecycleListener {
 
@@ -26,5 +33,10 @@ public final class VSphereConnectionPoolLifecycleListener {
         public void onChange(Saveable o, XmlFile file) {
             VSphereConnectionPoolRegistry.reapOrphans();
         }
+    }
+
+    @Terminator
+    public static void shutdownAllPoolsOnJenkinsShutdown() {
+        VSphereConnectionPoolRegistry.shutdownAll();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolLifecycleListener.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolLifecycleListener.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import hudson.Extension;
+import hudson.XmlFile;
+import hudson.model.Saveable;
+import hudson.model.listeners.SaveableListener;
+
+/**
+ * Keeps {@link VSphereConnectionPool} instances honest across an event that Jenkins core
+ * has no dedicated "cloud replaced/removed" hook for: saving the Jenkins configuration
+ * (e.g. the "Manage Jenkins &gt; Clouds" form, or a JCasC reload) replaces every
+ * reconfigured {@code vSphereCloud} with a brand new instance; the old instance - and the
+ * pool/background-thread/vCenter session it may still own - is simply dropped by Jenkins
+ * core with no notification. Without this listener that old pool keeps running under its
+ * previous settings indefinitely, which is very confusing to observe (it looks like
+ * configuration changes are being ignored).
+ */
+public final class VSphereConnectionPoolLifecycleListener {
+
+    private VSphereConnectionPoolLifecycleListener() {
+    }
+
+    @Extension
+    public static final class ReapOnSave extends SaveableListener {
+        @Override
+        public void onChange(Saveable o, XmlFile file) {
+            VSphereConnectionPoolRegistry.reapOrphans();
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolRegistry.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolRegistry.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+/**
+ * Tracks every {@link VSphereConnectionPool} currently in existence, so that pools left
+ * behind by a replaced/removed {@code vSphereCloud} instance (e.g. after the cloud config
+ * is re-saved from the UI or JCasC) can be found and shut down.
+ *
+ * <p>Without this, a pool's background thread (and any vCenter session it holds open)
+ * would otherwise keep running indefinitely under its old settings, invisible to anyone
+ * looking at the current cloud configuration.
+ */
+final class VSphereConnectionPoolRegistry {
+
+    private static final Logger LOGGER = Logger.getLogger(VSphereConnectionPoolRegistry.class.getName());
+
+    private static final Set<VSphereConnectionPool> LIVE_POOLS = ConcurrentHashMap.newKeySet();
+
+    private VSphereConnectionPoolRegistry() {
+    }
+
+    static void register(VSphereConnectionPool pool) {
+        LIVE_POOLS.add(pool);
+    }
+
+    static void unregister(VSphereConnectionPool pool) {
+        LIVE_POOLS.remove(pool);
+    }
+
+    /** Visible for testing: whether {@code pool} is still tracked (i.e. not shut down). */
+    static boolean isTracked(VSphereConnectionPool pool) {
+        return LIVE_POOLS.contains(pool);
+    }
+
+    /**
+     * Shuts down (and unregisters) every currently-registered pool whose owning cloud is
+     * no longer present in the live Jenkins configuration.
+     */
+    static void reapOrphans() {
+        for (VSphereConnectionPool pool : LIVE_POOLS) {
+            if (pool.isOrphaned()) {
+                LOGGER.info("Shutting down orphaned vSphere connection pool left behind by a replaced/removed cloud");
+                pool.shutdown();
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolRegistry.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolRegistry.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.vsphere.tools;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -7,7 +9,8 @@ import java.util.logging.Logger;
 /**
  * Tracks every {@link VSphereConnectionPool} currently in existence, so that pools left
  * behind by a replaced/removed {@code vSphereCloud} instance (e.g. after the cloud config
- * is re-saved from the UI or JCasC) can be found and shut down.
+ * is re-saved from the UI or JCasC) can be found and shut down, and so that all pools can
+ * be logged out together when Jenkins itself shuts down.
  *
  * <p>Without this, a pool's background thread (and any vCenter session it holds open)
  * would otherwise keep running indefinitely under its old settings, invisible to anyone
@@ -45,6 +48,17 @@ final class VSphereConnectionPoolRegistry {
                 LOGGER.info("Shutting down orphaned vSphere connection pool left behind by a replaced/removed cloud");
                 pool.shutdown();
             }
+        }
+    }
+
+    /**
+     * Shuts down (and unregisters) every currently-registered pool, regardless of whether
+     * its owning cloud is still live. Used when Jenkins itself is shutting down, so that
+     * pooled sessions are logged out rather than left dangling on the vCenter side.
+     */
+    static void shutdownAll() {
+        for (VSphereConnectionPool pool : new ArrayList<>(LIVE_POOLS)) {
+            pool.shutdown();
         }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
@@ -15,23 +15,23 @@
             <f:textbox clazz="required number" default="0"/>
         </f:entry>
 
-        <f:entry title="${%Reuse vSphere session (connection pool)}" field="useConnectionPool">
+        <f:entry title="${%Use vSphere connection pool}" field="useConnectionPool">
             <f:checkbox/>
         </f:entry>
-        <f:entry title="${%Pool health-check interval (seconds)}" field="poolHealthCheckIntervalSecs"
-                 description="0 — no periodic health checks.">
+        <f:entry title="${%Pool health check interval in seconds}" field="poolHealthCheckIntervalSecs"
+                 description="0 - no periodic health checks are performed.">
             <f:textbox clazz="number" default="0"/>
         </f:entry>
-        <f:entry title="${%Pool session max age (seconds)}" field="sessionMaxAgeSecs"
-                 description="0 — never restart based on age.">
+        <f:entry title="${%Pool session max age in seconds}" field="sessionMaxAgeSecs"
+                 description="0 - the session is never restarted based on age.">
             <f:textbox clazz="number" default="0"/>
         </f:entry>
         <f:entry title="${%Pool session max uses}" field="sessionMaxUses"
-                 description="0 — never restart based on use count.">
+                 description="0 - the session is never restarted based on use count.">
             <f:textbox clazz="number" default="0"/>
         </f:entry>
-        <f:entry title="${%Pool idle disconnect timeout (seconds)}" field="poolIdleTimeoutSecs"
-                 description="0 — keep the session alive indefinitely.">
+        <f:entry title="${%Pool idle disconnect timeout in seconds}" field="poolIdleTimeoutSecs"
+                 description="0 - the connection is kept alive indefinitely.">
             <f:textbox clazz="number" default="0"/>
         </f:entry>
     </f:advanced>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
@@ -14,6 +14,26 @@
         <f:entry title="${%Template Instance Cap}" field="instanceCap" description="0 means unlimited.">
             <f:textbox clazz="required number" default="0"/>
         </f:entry>
+
+        <f:entry title="${%Reuse vSphere session (connection pool)}" field="useConnectionPool">
+            <f:checkbox/>
+        </f:entry>
+        <f:entry title="${%Pool health-check interval (seconds)}" field="poolHealthCheckIntervalSecs"
+                 description="0 — no periodic health checks.">
+            <f:textbox clazz="number" default="0"/>
+        </f:entry>
+        <f:entry title="${%Pool session max age (seconds)}" field="sessionMaxAgeSecs"
+                 description="0 — never restart based on age.">
+            <f:textbox clazz="number" default="0"/>
+        </f:entry>
+        <f:entry title="${%Pool session max uses}" field="sessionMaxUses"
+                 description="0 — never restart based on use count.">
+            <f:textbox clazz="number" default="0"/>
+        </f:entry>
+        <f:entry title="${%Pool idle disconnect timeout (seconds)}" field="poolIdleTimeoutSecs"
+                 description="0 — keep the session alive indefinitely.">
+            <f:textbox clazz="number" default="0"/>
+        </f:entry>
     </f:advanced>
 
     <f:entry title="${%Templates}" description="${%List of Master VMs to be cloned as slaves}">

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolHealthCheckIntervalSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolHealthCheckIntervalSecs.html
@@ -1,0 +1,9 @@
+<div>
+  How often (in seconds) a background thread proactively checks that the pooled vSphere
+  session is still alive by issuing a lightweight <code>getCurrentTime()</code> call to
+  the vCenter.<br/>
+  If the call fails the pool reconnects immediately, so the next operation can proceed
+  without waiting for a timeout.<br/>
+  Set to <b>0</b> to disable health checks entirely — the pool will still reconnect
+  reactively if an operation fails due to an expired session.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolHealthCheckIntervalSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolHealthCheckIntervalSecs.html
@@ -4,6 +4,10 @@
   the vCenter.<br/>
   If the call fails the pool reconnects immediately, so the next operation can proceed
   without waiting for a timeout.<br/>
+  Each health check is itself one vCenter API invocation, so it will show up in the
+  vCenter Events log / API invocation counters even though it is not counted against
+  <b>Pool session max uses</b> below (that setting only counts sessions handed out to
+  Jenkins operations, e.g. clone/power-on/snapshot/delete).<br/>
   Set to <b>0</b> to disable health checks entirely — the pool will still reconnect
   reactively if an operation fails due to an expired session.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolHealthCheckIntervalSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolHealthCheckIntervalSecs.html
@@ -1,6 +1,6 @@
 <div>
   How often (in seconds) a background thread proactively checks that the pooled vSphere
-  session is still alive by issuing a lightweight <code>getCurrentTime()</code> call to
+  session is still alive by issuing a lightweight <code>currentTime()</code> call to
   the vCenter.<br/>
   If the call fails the pool reconnects immediately, so the next operation can proceed
   without waiting for a timeout.<br/>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolIdleTimeoutSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolIdleTimeoutSecs.html
@@ -1,0 +1,8 @@
+<div>
+  If no caller has requested the pooled session for this many seconds, the pool logs out
+  and releases the vCenter session.<br/>
+  The next request will transparently re-establish a new session.<br/>
+  This is useful in environments where idle sessions consume a limited licence slot or
+  where a security policy enforces periodic logout of inactive accounts.<br/>
+  Set to <b>0</b> to keep the session alive indefinitely regardless of activity.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolIdleTimeoutSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-poolIdleTimeoutSecs.html
@@ -1,6 +1,9 @@
 <div>
   If no caller has requested the pooled session for this many seconds, the pool logs out
   and releases the vCenter session.<br/>
+  This is enforced by a dedicated timer armed for the exact deadline (not a periodic
+  poll), so the logout happens right at the configured number of seconds rather than
+  some time after it.<br/>
   The next request will transparently re-establish a new session.<br/>
   This is useful in environments where idle sessions consume a limited licence slot or
   where a security policy enforces periodic logout of inactive accounts.<br/>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxAgeSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxAgeSecs.html
@@ -1,0 +1,9 @@
+<div>
+  Maximum lifetime of a pooled session in seconds, measured from when the session was
+  established.<br/>
+  Once this limit is reached the pool proactively logs out the old session and creates a
+  fresh one before serving the next request.<br/>
+  This is useful if your vCenter enforces a maximum session duration (e.g. 8 hours) or
+  if you want to rotate credentials regularly.<br/>
+  Set to <b>0</b> to never restart based on session age.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxAgeSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxAgeSecs.html
@@ -7,5 +7,10 @@
   time after it.<br/>
   This is useful if your vCenter enforces a maximum session duration (e.g. 8 hours) or
   if you want to rotate credentials regularly.<br/>
+  If <b>Pool idle disconnect timeout</b> is also set, and no Jenkins operation has
+  actually used the session since it was established, reaching the max age disconnects
+  the session instead of rotating it - the idle setting takes priority over rotating a
+  session nobody is using, so an unused session does not keep reconnecting forever when
+  the max age is shorter than the idle timeout.<br/>
   Set to <b>0</b> to never restart based on session age.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxAgeSecs.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxAgeSecs.html
@@ -2,7 +2,9 @@
   Maximum lifetime of a pooled session in seconds, measured from when the session was
   established.<br/>
   Once this limit is reached the pool proactively logs out the old session and creates a
-  fresh one before serving the next request.<br/>
+  fresh one; this is enforced by a dedicated timer armed for the exact deadline (not a
+  periodic poll), so the rotation happens right at the configured age rather than some
+  time after it.<br/>
   This is useful if your vCenter enforces a maximum session duration (e.g. 8 hours) or
   if you want to rotate credentials regularly.<br/>
   Set to <b>0</b> to never restart based on session age.

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxUses.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxUses.html
@@ -1,0 +1,7 @@
+<div>
+  Maximum number of times the pooled session may be handed out before the pool restarts
+  it on the next request.<br/>
+  This provides a use-count-based rotation independent of how long the session has been
+  alive.<br/>
+  Set to <b>0</b> to never restart based on use count.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxUses.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-sessionMaxUses.html
@@ -1,6 +1,12 @@
 <div>
   Maximum number of times the pooled session may be handed out before the pool restarts
   it on the next request.<br/>
+  This counts <b>Jenkins-level operations</b> (each acquisition of the shared session by
+  a clone/power-on/snapshot/delete/etc. step) - not the number of individual vCenter SOAP
+  calls those operations make internally, and not background health checks.<br/>
+  The limit is enforced atomically: an operation that has already acquired the session
+  always finishes on it, and only the <em>next</em> request triggers the restart, so a
+  single logical operation is never interrupted mid-way.<br/>
   This provides a use-count-based rotation independent of how long the session has been
   alive.<br/>
   Set to <b>0</b> to never restart based on use count.

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useConnectionPool.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useConnectionPool.html
@@ -1,0 +1,56 @@
+<div>
+  <p>
+    When enabled, all vSphere API calls made by this cloud share one long-lived session
+    instead of performing a full <em>login → operation → logout</em> cycle for every
+    individual request (clone, power-on, snapshot revert, delete, …).
+    This eliminates dozens of redundant authentication round-trips per agent lifecycle,
+    reducing load on the vCenter and speeding up provisioning.
+  </p>
+  <p>
+    The shared session is created on the first request and kept alive in the background
+    according to the health-check, age, use-count, and idle-timeout settings below.
+    If the session expires unexpectedly (e.g. the vCenter was restarted) the pool
+    reconnects automatically on the next request.
+  </p>
+  <p>
+    Leave disabled if you prefer the original stateless behaviour (a fresh login per
+    operation), for example when multiple Jenkins controllers share the same vCenter
+    account with a strict concurrent-session limit.
+  </p>
+
+  <h4>Configuration via JCasC (Configuration as Code)</h4>
+  <p>
+    Add the following keys under the <code>vSphere</code> cloud entry in your
+    <code>jenkins.yaml</code>.  Only <code>useConnectionPool: true</code> is required;
+    the remaining keys default to <code>0</code> (feature disabled).
+  </p>
+  <pre>
+jenkins:
+  clouds:
+    - vSphere:
+        vsDescription: "My vCenter"
+        vsConnectionConfig:
+          vsHost: "https://vcenter.example.com"
+          credentialsId: "vcenter-creds"
+        instanceCap: 20
+        maxOnlineSlaves: 0
+
+        # --- Connection pool settings ---
+        useConnectionPool: true
+
+        # Re-check session health every 60 seconds (0 = disabled)
+        poolHealthCheckIntervalSecs: 60
+
+        # Restart the session after 1 hour regardless of activity (0 = never)
+        sessionMaxAgeSecs: 3600
+
+        # Restart after 500 uses (0 = never)
+        sessionMaxUses: 500
+
+        # Disconnect after 5 minutes of no activity (0 = keep alive forever)
+        poolIdleTimeoutSecs: 300
+
+        templates:
+          - ...
+  </pre>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useConnectionPool.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useConnectionPool.html
@@ -17,6 +17,11 @@
     operation), for example when multiple Jenkins controllers share the same vCenter
     account with a strict concurrent-session limit.
   </p>
+  <p>
+    Saving this cloud's configuration (from the UI or via JCasC reload) always replaces
+    it with a fresh pool using the new settings; the previous pool - and any session it
+    still holds open - is logged out shortly afterwards.
+  </p>
 
   <h4>Configuration via JCasC (Configuration as Code)</h4>
   <p>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useConnectionPool.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-useConnectionPool.html
@@ -20,7 +20,8 @@
   <p>
     Saving this cloud's configuration (from the UI or via JCasC reload) always replaces
     it with a fresh pool using the new settings; the previous pool - and any session it
-    still holds open - is logged out shortly afterwards.
+    still holds open - is logged out shortly afterwards. All pooled sessions are also
+    logged out when Jenkins itself shuts down.
   </p>
 
   <h4>Configuration via JCasC (Configuration as Code)</h4>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
@@ -55,6 +55,28 @@ class ConfigurationAsCodeTest {
         validateCasCExport();
     }
 
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void pool_is_disabled_by_default_when_not_specified_in_yaml(JenkinsConfiguredWithCodeRule r) {
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        assertThat(cloud.isUseConnectionPool(), is(false));
+        assertThat(cloud.getPoolHealthCheckIntervalSecs(), is(0));
+        assertThat(cloud.getSessionMaxAgeSecs(), is(0));
+        assertThat(cloud.getSessionMaxUses(), is(0));
+        assertThat(cloud.getPoolIdleTimeoutSecs(), is(0));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-with-pool.yml")
+    void should_load_pool_configuration_from_yaml(JenkinsConfiguredWithCodeRule r) {
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        assertThat(cloud.isUseConnectionPool(), is(true));
+        assertThat(cloud.getPoolHealthCheckIntervalSecs(), is(60));
+        assertThat(cloud.getSessionMaxAgeSecs(), is(3600));
+        assertThat(cloud.getSessionMaxUses(), is(500));
+        assertThat(cloud.getPoolIdleTimeoutSecs(), is(300));
+    }
+
     private static void validateCasCLoading(vSphereCloud cloud) {
         assertThat(cloud.getVsDescription(), is("Company vSphere"));
         assertThat(cloud.getVsHost(), is("https://company-vsphere"));

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolOrphanReapingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolOrphanReapingTest.java
@@ -1,0 +1,59 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.jenkinsci.plugins.vSphereCloud;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Covers the fix for PR #176's reported symptom where re-saving the cloud configuration
+ * left the previous {@code vSphereCloud}'s connection pool (and its background thread /
+ * vCenter session) running indefinitely under its old settings, since Jenkins core
+ * replaces a reconfigured {@link hudson.slaves.Cloud} with no destroy/removal hook.
+ */
+@WithJenkinsConfiguredWithCode
+class VSphereConnectionPoolOrphanReapingTest {
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void pool_is_not_reaped_while_its_owning_cloud_is_still_registered(JenkinsConfiguredWithCodeRule r) {
+        vSphereCloud owner = new vSphereCloud(makeConnectionConfig(), "orphan-owner", 0, 0, null);
+        r.jenkins.clouds.add(owner);
+        VSphereConnectionPool pool = new VSphereConnectionPool(makeConnectionConfig(), owner, 0, 0, 0, 0);
+        try {
+            assertThat(pool.isOrphaned(), is(false));
+
+            VSphereConnectionPoolRegistry.reapOrphans();
+
+            assertThat(VSphereConnectionPoolRegistry.isTracked(pool), is(true));
+        } finally {
+            r.jenkins.clouds.remove(owner);
+            pool.shutdown();
+        }
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void pool_is_reaped_once_its_owning_cloud_is_replaced(JenkinsConfiguredWithCodeRule r) {
+        vSphereCloud owner = new vSphereCloud(makeConnectionConfig(), "orphan-owner", 0, 0, null);
+        r.jenkins.clouds.add(owner);
+        VSphereConnectionPool pool = new VSphereConnectionPool(makeConnectionConfig(), owner, 0, 0, 0, 0);
+
+        // Simulate what Jenkins core does when the cloud config is re-saved: the old
+        // Cloud instance is dropped from Jenkins.clouds in favour of a new one.
+        r.jenkins.clouds.remove(owner);
+        assertThat(pool.isOrphaned(), is(true));
+
+        VSphereConnectionPoolRegistry.reapOrphans();
+
+        assertThat(VSphereConnectionPoolRegistry.isTracked(pool), is(false));
+    }
+
+    private static org.jenkinsci.plugins.vsphere.VSphereConnectionConfig makeConnectionConfig() {
+        return new org.jenkinsci.plugins.vsphere.VSphereConnectionConfig("https://test-host", false, null);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolSettingsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereConnectionPoolSettingsTest.java
@@ -1,0 +1,129 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import org.jenkinsci.plugins.vSphereCloud;
+import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Unit tests for the connection-pool toggle and associated settings on
+ * {@link vSphereCloud} and {@link VSphereConnectionPool}.
+ *
+ * No live vSphere connection is required; these tests exercise configuration
+ * plumbing only.
+ */
+class VSphereConnectionPoolSettingsTest {
+
+    // -----------------------------------------------------------------------
+    // Default values — pool must be OFF by default (principle of least surprise)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void pool_is_disabled_by_default() {
+        assertThat(makeCloud().isUseConnectionPool(), is(false));
+    }
+
+    @Test
+    void pool_integer_settings_default_to_zero() {
+        vSphereCloud cloud = makeCloud();
+        assertThat(cloud.getPoolHealthCheckIntervalSecs(), is(0));
+        assertThat(cloud.getSessionMaxAgeSecs(), is(0));
+        assertThat(cloud.getSessionMaxUses(), is(0));
+        assertThat(cloud.getPoolIdleTimeoutSecs(), is(0));
+    }
+
+    // -----------------------------------------------------------------------
+    // Setter / getter round-trips
+    // -----------------------------------------------------------------------
+
+    @Test
+    void pool_settings_are_stored_and_retrieved_correctly() {
+        vSphereCloud cloud = makeCloud();
+
+        cloud.setUseConnectionPool(true);
+        cloud.setPoolHealthCheckIntervalSecs(60);
+        cloud.setSessionMaxAgeSecs(3600);
+        cloud.setSessionMaxUses(500);
+        cloud.setPoolIdleTimeoutSecs(300);
+
+        assertThat(cloud.isUseConnectionPool(), is(true));
+        assertThat(cloud.getPoolHealthCheckIntervalSecs(), is(60));
+        assertThat(cloud.getSessionMaxAgeSecs(), is(3600));
+        assertThat(cloud.getSessionMaxUses(), is(500));
+        assertThat(cloud.getPoolIdleTimeoutSecs(), is(300));
+    }
+
+    @Test
+    void disabling_pool_restores_flag_to_false() {
+        vSphereCloud cloud = makeCloud();
+        cloud.setUseConnectionPool(true);
+        cloud.setUseConnectionPool(false);
+        assertThat(cloud.isUseConnectionPool(), is(false));
+    }
+
+    @Test
+    void zero_is_a_valid_value_for_each_integer_setting() {
+        vSphereCloud cloud = makeCloud();
+        cloud.setUseConnectionPool(true);
+        cloud.setPoolHealthCheckIntervalSecs(0);
+        cloud.setSessionMaxAgeSecs(0);
+        cloud.setSessionMaxUses(0);
+        cloud.setPoolIdleTimeoutSecs(0);
+
+        assertThat(cloud.getPoolHealthCheckIntervalSecs(), is(0));
+        assertThat(cloud.getSessionMaxAgeSecs(), is(0));
+        assertThat(cloud.getSessionMaxUses(), is(0));
+        assertThat(cloud.getPoolIdleTimeoutSecs(), is(0));
+    }
+
+    // -----------------------------------------------------------------------
+    // VSphereConnectionPool lifecycle (no live vSphere needed)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void pool_shutdown_is_safe_before_any_connection() {
+        // Pool with background threads; shut down immediately — must not throw.
+        VSphereConnectionPool pool = new VSphereConnectionPool(
+                makeConnectionConfig(), 30, 3600, 0, 300);
+        pool.shutdown();
+    }
+
+    @Test
+    void pool_with_all_features_disabled_does_not_start_scheduler() {
+        // All-zero config → no background thread is started.
+        VSphereConnectionPool pool = new VSphereConnectionPool(
+                makeConnectionConfig(), 0, 0, 0, 0);
+        pool.shutdown(); // must be safe even with no scheduler
+    }
+
+    @Test
+    void pool_clamps_negative_arguments_to_zero() {
+        // Negative values must be silently clamped; no exception expected.
+        VSphereConnectionPool pool = new VSphereConnectionPool(
+                makeConnectionConfig(), -1, -100, -5, -60);
+        pool.shutdown();
+    }
+
+    @Test
+    void pool_shutdown_is_idempotent() {
+        VSphereConnectionPool pool = new VSphereConnectionPool(
+                makeConnectionConfig(), 0, 0, 0, 0);
+        pool.shutdown();
+        pool.shutdown(); // second call must not throw
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static vSphereCloud makeCloud() {
+        return new vSphereCloud(makeConnectionConfig(), "test-cloud", 0, 0, null);
+    }
+
+    private static VSphereConnectionConfig makeConnectionConfig() {
+        // 3-arg internal constructor: host, allowUntrustedCertificate, credentialsId
+        return new VSphereConnectionConfig("https://test-host", false, null);
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-pool.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-pool.yml
@@ -1,0 +1,14 @@
+jenkins:
+  systemMessage: "Hello World"
+  clouds:
+    - vSphere:
+        instanceCap: 0
+        maxOnlineSlaves: 0
+        useConnectionPool: true
+        poolHealthCheckIntervalSecs: 60
+        sessionMaxAgeSecs: 3600
+        sessionMaxUses: 500
+        poolIdleTimeoutSecs: 300
+        vsConnectionConfig:
+          vsHost: "https://company-vsphere"
+        vsDescription: "Pool Test vSphere"


### PR DESCRIPTION
*Research and implementation augmented by AI (Claude); testing against real vCenter and feedback to AI is performed manually*

Every vSphere API call — find template, clone VM, configure, power on, wait for tools, revert snapshot, delete clone — previously performed a full login → operation → logout cycle.  With multiple agents being provisioned concurrently this produced dozens of authentication round-trips per second against vCenter, increasing latency and load.

Three call sites additionally leaked sessions by never calling disconnect() at all:
  - vSphereCloudSlave.doTestConnection,
  - vSphereCloudSlaveComputer.getVMInformation,
  - vSphereCloudLauncher.revertVM

A single long-lived vSphere session per vSphereCloud instance. Callers continue to call vSphereInstance() / disconnect() exactly as before; when the pool is active, disconnect() becomes a no-op and the pool manages the real session lifecycle via background maintenance:

  - Health check (configurable interval): issues a lightweight currentTime() SOAP call; reconnects automatically on failure.
  - Session age limit: proactively restarts the session after N seconds to comply with vCenter session-duration policies.
  - Use-count limit: restarts after N acquisitions, independently of age.
  - Idle disconnect: logs out after N seconds of inactivity; the next acquire() transparently re-establishes the session.

Each feature is independently enabled/disabled via its own integer setting; 0 means the feature is disabled.  The pool is disabled entirely by default (useConnectionPool = false) to preserve the existing stateless behaviour.

The pool holds ONE connection per cloud instance (not a pool of N connections), because VSphere itself is stateless — its session token is immutable and all operations create fresh ServiceInstance objects, so concurrent callers share the same instance safely.

  - volatile boolean pooled field: when true, disconnect() returns immediately instead of calling logout().
  - markAsPooled() / forceDisconnect(): package-private methods called only by VSphereConnectionPool to control the real logout.
  - isSessionAlive(): public; issues currentTime() and returns true/false — used by the pool health-check thread. Note: the correct yavijava 9.0.2 method name is currentTime(), not getCurrentTime() which does not exist in this version.

Five new DataBoundSetter fields (all default 0 / false):

  | useConnectionPool           | boolean  | master toggle |
  | poolHealthCheckIntervalSecs | int      | seconds; 0 = no health checks |
  | sessionMaxAgeSecs           | int      | seconds; 0 = never restart |
  | sessionMaxUses              | int      | count;   0 = never restart |
  | poolIdleTimeoutSecs         | int     | seconds; 0 = keep alive forever |

vSphereInstance() routes through getOrCreatePool() when the toggle is on.  Each setter calls resetPool() so that live reconfiguration via JCasC or the UI immediately takes effect with a fresh session.

  - config.jelly: five new entries inside <f:advanced>
  - help-useConnectionPool.html: overview + full JCasC YAML example
  - help-poolHealthCheckIntervalSecs.html
  - help-sessionMaxAgeSecs.html
  - help-sessionMaxUses.html
  - help-poolIdleTimeoutSecs.html

clouds:
```
  - vSphere: vsDescription: "My vCenter" vsConnectionConfig: vsHost: "https://vcenter.example.com" credentialsId: "vcenter-creds" useConnectionPool: true
      poolHealthCheckIntervalSecs: 60    # 0 = disabled
      sessionMaxAgeSecs: 3600            # 0 = never restart on age
      sessionMaxUses: 500                # 0 = never restart on count
      poolIdleTimeoutSecs: 300           # 0 = keep alive indefinitely
```

Three call sites that obtained a VSphere instance without ever calling disconnect() have been fixed with try/finally blocks:

  - vSphereCloudSlave.DescriptorImpl.doTestConnection() — was creating up to two sessions (one for VM lookup, one for snapshot lookup) and leaking both; refactored to a single session covering both lookups.
  - vSphereCloudSlaveComputer.getVMInformation() — leaked the session after fetching VM properties for the computer detail panel.
  - vSphereCloudLauncher.revertVM() — leaked the session used to resolve the snapshot reference before reverting.

  - VSphereConnectionPoolSettingsTest (9 unit tests, no Jenkins needed): verifies pool is off by default, integer settings default to zero, setter round-trips, pool shutdown is safe/idempotent, negative constructor arguments are clamped to zero.
  - configuration-as-code-with-pool.yml: new JCasC fixture with all five pool fields set to non-default values.
  - ConfigurationAsCodeTest: two new methods — pool_is_disabled_by_default_when_not_specified_in_yaml and should_load_pool_configuration_from_yaml.

### Testing done

Will be tested in-house in the coming weeks/months.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
