### PR TITLE
[JENKINS-76498] Fix NullPointerException when reverting to a VM snapshot

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -197,7 +197,7 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                         }
 
                         vSphereCloud.Log(slaveComputer, taskListener, "Reverting to snapshot:" + snapName);
-                        Task task = snap.revertToSnapshot_Task(null);
+                        Task task = snap.revertToSnapshot_Task(null, Boolean.FALSE);
                         if (!task.waitForTask().equals(Task.SUCCESS)) {
                             throw new IOException("Error while reverting to virtual machine snapshot");
                         }
@@ -504,7 +504,7 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
             }
 
             vSphereCloud.Log(slaveComputer, taskListener, "Reverting to snapshot:" + snapName);
-            Task task = snap.revertToSnapshot_Task(null);
+            Task task = snap.revertToSnapshot_Task(null, Boolean.FALSE);
             if (!task.waitForTask().equals(Task.SUCCESS)) {
                 throw new IOException("Error while reverting to virtual machine snapshot");
             }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot.java
@@ -34,6 +34,7 @@ import org.jenkinsci.plugins.vsphere.tools.VSphereException;
 import org.jenkinsci.plugins.vsphere.tools.VSphereLogger;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -41,8 +42,9 @@ import com.vmware.vim25.mo.VirtualMachineSnapshot;
 
 public class RevertToSnapshot extends VSphereBuildStep implements SimpleBuildStep {
 
-	private final String vm;    
+	private final String vm;
 	private final String snapshotName;
+    private boolean suppressPowerOn;
 
 	@DataBoundConstructor
 	public RevertToSnapshot(final String vm, final String snapshotName) throws VSphereException {
@@ -56,6 +58,15 @@ public class RevertToSnapshot extends VSphereBuildStep implements SimpleBuildSte
 
 	public String getSnapshotName() {
 		return snapshotName;
+	}
+
+	public boolean isSuppressPowerOn() {
+		return suppressPowerOn;
+	}
+
+	@DataBoundSetter
+	public void setSuppressPowerOn(boolean suppressPowerOn) {
+		this.suppressPowerOn = suppressPowerOn;
 	}
 
 	@Override
@@ -117,7 +128,7 @@ public class RevertToSnapshot extends VSphereBuildStep implements SimpleBuildSte
 		}
 
 		VSphereLogger.vsLogger(jLogger, "Reverting to snapshot \""+expandedSnap+"\" for VM "+expandedVm+"...");
-		vsphere.revertToSnapshot(expandedVm, expandedSnap);
+		vsphere.revertToSnapshot(expandedVm, expandedSnap, suppressPowerOn);
 		VSphereLogger.vsLogger(jLogger, "Complete.");
 
 		return true;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -519,6 +519,10 @@ public class VSphere {
     }
 
     public void revertToSnapshot(String vmName, String snapName) throws VSphereException {
+        revertToSnapshot(vmName, snapName, false);
+    }
+
+    public void revertToSnapshot(String vmName, String snapName, boolean suppressPowerOn) throws VSphereException {
 
         VirtualMachine vm = getVmByName(vmName);
         VirtualMachineSnapshot snap = getSnapshotInTree(vm, snapName);
@@ -529,7 +533,7 @@ public class VSphere {
         }
 
         try {
-            Task task = snap.revertToSnapshot_Task(null);
+            Task task = snap.revertToSnapshot_Task(null, Boolean.valueOf(suppressPowerOn));
             if (!task.waitForTask().equals(Task.SUCCESS)) {
                 final String msg = "Could not revert to snapshot '" + snap.toString() + "' for virtual machine:'" + vm.getName()+"'";
                 LOGGER.log(Level.SEVERE, msg);

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot/config.jelly
@@ -24,5 +24,9 @@ limitations under the License.
     <f:textbox />
   </f:entry>
 
+  <f:entry title="${%Suppress power on?}" field="suppressPowerOn">
+    <f:checkbox />
+  </f:entry>
+
   <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm,snapshotName"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot/help-suppressPowerOn
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshot/help-suppressPowerOn
@@ -1,0 +1,5 @@
+<div>
+ Leave the VM powered off after reverting, regardless of the power state captured in the
+ snapshot. When unchecked (the default), the VM is restored to the power state recorded in
+ the snapshot.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshotTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/RevertToSnapshotTest.java
@@ -1,0 +1,54 @@
+package org.jenkinsci.plugins.vsphere.builders;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@WithJenkins
+class RevertToSnapshotTest {
+
+    @Test
+    @Issue("JENKINS-76498")
+    void suppressPowerOnIsAKnownDataBoundParameter(JenkinsRule r) {
+        // Guards against a regression of the "Unknown parameter" warning: the model must
+        // advertise suppressPowerOn as a settable parameter of the build step.
+        DescribableModel<RevertToSnapshot> model = DescribableModel.of(RevertToSnapshot.class);
+        assertThat(model.getParameter("suppressPowerOn"), notNullValue());
+    }
+
+    @Test
+    void suppressPowerOnDefaultsToFalse(JenkinsRule r) throws Exception {
+        // Backward compatibility: existing configs / pipelines that omit the field must behave
+        // exactly as before (power state restored from the snapshot).
+        Map<String, Object> args = new HashMap<>();
+        args.put("vm", "some-vm");
+        args.put("snapshotName", "clean");
+
+        RevertToSnapshot step = DescribableModel.of(RevertToSnapshot.class).instantiate(args);
+
+        assertThat(step.getVm(), is("some-vm"));
+        assertThat(step.getSnapshotName(), is("clean"));
+        assertThat(step.isSuppressPowerOn(), is(false));
+    }
+
+    @Test
+    @Issue("JENKINS-76498")
+    void suppressPowerOnIsHonouredWhenSet(JenkinsRule r) throws Exception {
+        Map<String, Object> args = new HashMap<>();
+        args.put("vm", "some-vm");
+        args.put("snapshotName", "clean");
+        args.put("suppressPowerOn", true);
+
+        RevertToSnapshot step = DescribableModel.of(RevertToSnapshot.class).instantiate(args);
+
+        assertThat(step.isSuppressPowerOn(), is(true));
+    }
+}


### PR DESCRIPTION
# JENKINS-76498 — Fix NullPointerException reverting to a VM snapshot (+ optional "suppress power on")

https://issues.jenkins.io/browse/JENKINS-76498

## Problem
Reverting a VM to a **named** snapshot throws a `NullPointerException` before the
revert is performed. This affects both the "Revert to Snapshot" build step and the
cloud-agent path that reverts a template snapshot when a vSphere agent launches, so
snapshot-based workflows fail outright.

- **What:** revert a VM to a named snapshot (build step, or agent revert-on-launch).
- **How it fails:** the build fails during the snapshot revert. Pipeline console output:
  ```
  [vSphere] Reverting to snapshot "clean" for VM <vm-name>...
  [Pipeline] End of Pipeline
  ERROR: Cannot invoke "java.lang.Boolean.booleanValue()" because "suppressPowerOn" is null
  Finished: FAILURE
  ```
  The JDK "Helpful NullPointerException" message (JEP 358) names the culprit exactly:
  the boxed `Boolean suppressPowerOn` is `null` and is being unboxed via `booleanValue()`.
- **Expected:** the VM reverts to the named snapshot and the build/agent continues.

## Root cause
Exposed by the yavijava 6.0.05→9.0.2 upgrade (commit d1fbc74): the generated VimPortType.revertToSnapshot_Task binding changed its suppressPowerOn parameter from a nullable Boolean to a primitive boolean, so the SDK now unboxes it unconditionally and the plugin's long-standing single-arg revertToSnapshot_Task(null) calls throw an NPE.

The plugin calls `VirtualMachineSnapshot.revertToSnapshot_Task(HostSystem)` — the
single-argument overload in the bundled yavijava SDK. That overload delegates to
`revertToSnapshot_Task(HostSystem, Boolean suppressPowerOn)` passing a **null**
`Boolean`. During SOAP serialization the boxed `Boolean` is unboxed to a primitive,
and unboxing `null` throws the NPE. By contrast `revertToCurrentSnapshot_Task` takes a
primitive `boolean`, which is why "revert to current snapshot" was unaffected while
"revert to named snapshot" failed.

## Fix
Pass an explicit non-null `Boolean` (`false`, the historical default) at every call site:
- `tools/VSphere.java` — `revertToSnapshot(...)` now calls
  `revertToSnapshot_Task(host, Boolean.valueOf(suppressPowerOn))`.
- `vSphereCloudLauncher.java` — the two agent revert-on-launch call sites now pass
  `Boolean.FALSE`.

`false` means "restore the power state recorded in the snapshot" — exactly the prior
behavior, so existing users see no change.

## Enhancement (opt-in, default off)
Since the SDK already supports it, this also exposes `suppressPowerOn` as an optional
parameter of the "Revert to Snapshot" build step:
- `builders/RevertToSnapshot.java` — new `suppressPowerOn` field via `@DataBoundSetter`
  (the `@DataBoundConstructor` signature is unchanged).
- `RevertToSnapshot/config.jelly` — a checkbox for the field.
- `RevertToSnapshot/help-suppressPowerOn.html` — help text describing the field and its
  default.

When enabled, the VM is left powered off after the revert regardless of the power state
captured in the snapshot.

## Backwards compatibility
- No constructor signatures changed; existing job config and pipeline scripts load as-is.
- Default (`suppressPowerOn = false`) is identical to prior releases.
- No breaking changes.

## Tests
Adds `builders/RevertToSnapshotTest.java` — three unit tests that do **not** require a
live vSphere (they exercise the pipeline data-binding path via `DescribableModel`):
1. `suppressPowerOn` is recognized as a data-bound parameter (guards the
   "Unknown parameter" regression).
2. Omitting the field defaults to `false`.
3. Setting the field to `true` is honored.

`mvn -Dtest=RevertToSnapshotTest test` → `Tests run: 3, Failures: 0, Errors: 0`.

## Environment reproduced on
- Jenkins core: 2.568.1 (LTS, JDK 21)
- Plugin version: 4.530.v1b_68fb_22777c