### PR TITLE
Add optional explicit and automatic ESXi host selection for VM clones

### DIFF
--- a/docs/jenkins-configuration.md
+++ b/docs/jenkins-configuration.md
@@ -82,7 +82,7 @@ Ticking this enables the following:
   Recommended for short-lived VMs as otherwise it takes longer to clone the disks than it does for anything else.
 * Enter Cluster, Resource Pool, Datastore, Folder, Customization Specification as required, this are settings how the clone will be created in vSphere.
 Enter "Resources" as default for "Resource Pool" if you haven't explicitly defined resource pools in vCenter.
-* Target Host, Host Selection Mode, Candidate Hosts (all optional, under "Advanced..."):
+* Target Host, Host Selection Mode, Host Selection Candidates (all optional, under "Advanced..."):
 control which ESXi host within the Cluster new clones are placed on.
 See ["Controlling which ESXi host a clone lands on"](#controlling-which-esxi-host-a-clone-lands-on) below for details and examples.
 Leaving these blank preserves the historical behaviour (vCenter's own default placement, unaffected by this feature).
@@ -141,7 +141,7 @@ Note that any such functionality is dependent on there being support for it in t
 This build step will clone an existing Template or VM to a new VM.
 Linked clones are optional.
 Cluster, Resource Pool, and Datastore can be specified.
-Under "Advanced...", Host, Host Selection Mode and Candidate Hosts can be used to control
+Under "Advanced...", Host, Host Selection Mode and Host Selection Candidates can be used to control
 which ESXi host the clone is placed on - see
 ["Controlling which ESXi host a clone lands on"](#controlling-which-esxi-host-a-clone-lands-on)
 below.
@@ -152,7 +152,7 @@ This build step will create a VM from the specified template.
 The template must have at least one snapshot before it can be cloned.
 A linked clone may optionally be chosen.
 The new VM will be placed in the same folder and storage device as the original template, and will use the specified ResourcePool and Cluster.
-Under "Advanced...", Host, Host Selection Mode and Candidate Hosts can be used to control
+Under "Advanced...", Host, Host Selection Mode and Host Selection Candidates can be used to control
 which ESXi host the clone is placed on - see
 ["Controlling which ESXi host a clone lands on"](#controlling-which-esxi-host-a-clone-lands-on)
 below.
@@ -191,20 +191,31 @@ Three independent, optional mechanisms are available, in order of precedence:
      is the recommended choice for enterprise environments that already rely on DRS, so
      that Jenkins agent placement follows the same policy as everything else.
 
-3. **Candidate Hosts** (`candidateHosts`) - an optional comma-separated allow-list, e.g.
-   `esx01.example.com, esx02.example.com, esx03.example.com`, that restricts what "Host
-   Selection Mode" is allowed to consider. Not every host visible in a cluster is
-   necessarily usable by the vCenter account running the connection - a vCenter admin
-   may restrict provisioning permission to a subset of hosts - so this is the mechanism
-   to keep automatic selection within permitted hosts. It is **not verified live**
-   against actual vCenter permissions: an incorrect entry, or a host the account cannot
-   actually write to, only surfaces as a vCenter-side error when a clone is attempted.
-   Leave blank to consider every (connected, non-maintenance-mode) host in the cluster.
+   Either mode needs a cluster to search within. If "Cluster" is left blank, the plugin
+   will use the vCenter's only cluster when there is exactly one; if there are zero or
+   several clusters, it logs a message and falls back to letting vCenter decide (as if
+   `hostSelectionMode` had been left blank too), rather than guessing.
+
+3. **Host Selection Candidates** - an optional allow-list that restricts what "Host
+   Selection Mode" is allowed to consider. In the classic UI it's a single comma-separated
+   textbox (`hostSelectionCandidatesAsString`), e.g.
+   `esx01.example.com, esx02.example.com, esx03.example.com`. In a pipeline or
+   Configuration-as-Code YAML you can use that same comma-separated string under the name
+   `hostSelectionCandidatesAsString`, or instead give a native list of host names under
+   `hostSelectionCandidates` (`['esx01.example.com', 'esx02.example.com']`) - whichever is
+   more convenient; both end up stored the same way (use only one of the two per
+   template/step). Not every host visible in a cluster is necessarily usable by the
+   vCenter account running the connection - a vCenter admin may restrict provisioning
+   permission to a subset of hosts - so this is the mechanism to keep automatic selection
+   within permitted hosts. It is **not verified live** against actual vCenter permissions:
+   an incorrect entry, or a host the account cannot actually write to, only surfaces as a
+   vCenter-side error when a clone is attempted. Leave blank to consider every (connected,
+   non-maintenance-mode) host in the cluster.
 
 In short: pick "Host" for a fixed lab setup, `LEAST_LOADED` if you want basic load
 spreading without a DRS license, or `DRS_RECOMMENDED` if you're already on Enterprise
 Plus (or similar) and want placement to follow the same DRS policy as the rest of the
-cluster; use "Candidate Hosts" whenever the automation account can't write to every
+cluster; use "Host Selection Candidates" whenever the automation account can't write to every
 host vCenter shows you.
 
 #### Convert VM to Template

--- a/docs/jenkins-configuration.md
+++ b/docs/jenkins-configuration.md
@@ -26,6 +26,14 @@ If you do not have existing credentials defined for this within Jenkins then you
 
 The "Test Connection" button will test to see if your vSphere is accessible with the specified host name, user name and password.
 
+Under "Advanced...", "Default Host Selection Mode" and "Default Host Selection Candidates"
+let you set a cloud-wide default for how clones are placed on a host, applied to every
+template and build step that uses this cloud and doesn't set its own value. See
+["Controlling which ESXi host a clone lands on"](#controlling-which-esxi-host-a-clone-lands-on)
+below - which hosts an account can write to, and whether DRS is licensed, are properties
+of this vCenter environment, so setting them once here avoids repeating the same choice
+on every template/pipeline call using this cloud.
+
 The user entered when defining the cloud will need to have the following vsphere permissions:
 
 |     |                                                                                                                                                      |
@@ -176,6 +184,13 @@ Three independent, optional mechanisms are available, in order of precedence:
 
 2. **Host Selection Mode** (`hostSelectionMode`) - used only when "Host" is blank, this
    lets the plugin pick automatically:
+   * *(blank)* - inherits the cloud's own "Default Host Selection Mode" (see
+     [vSphere Cloud Configuration](#vsphere-cloud-configuration) above), if any; if the
+     cloud has no default either, this is unchanged legacy behaviour.
+   * `NONE` - explicitly disables host selection **for this call site**, overriding the
+     cloud's default even if it has one configured. Use this on the specific
+     template/pipeline that should keep the old behaviour while everything else on the
+     same cloud follows the cloud-wide default.
    * `LEAST_LOADED` - the plugin reads current CPU/memory usage for each candidate host
      and picks the least loaded one itself. No DRS license/feature is required, so this
      works on Essentials/Standard editions or on a cluster with DRS turned off. It does
@@ -209,14 +224,22 @@ Three independent, optional mechanisms are available, in order of precedence:
    permission to a subset of hosts - so this is the mechanism to keep automatic selection
    within permitted hosts. It is **not verified live** against actual vCenter permissions:
    an incorrect entry, or a host the account cannot actually write to, only surfaces as a
-   vCenter-side error when a clone is attempted. Leave blank to consider every (connected,
-   non-maintenance-mode) host in the cluster.
+   vCenter-side error when a clone is attempted.
+   * *(blank)* - inherits the cloud's own "Default Host Selection Candidates", if any; if
+     the cloud has no default either, every (connected, non-maintenance-mode) host in the
+     cluster is a candidate.
+   * a single comma (`,`) - explicitly overrides to "no restriction" **for this call
+     site**, even if the cloud has a default candidate list configured. This is not
+     blank, so it's treated as a deliberate override rather than "inherit", even though
+     it also parses to zero host names.
 
 In short: pick "Host" for a fixed lab setup, `LEAST_LOADED` if you want basic load
 spreading without a DRS license, or `DRS_RECOMMENDED` if you're already on Enterprise
 Plus (or similar) and want placement to follow the same DRS policy as the rest of the
 cluster; use "Host Selection Candidates" whenever the automation account can't write to every
-host vCenter shows you.
+host vCenter shows you. If most templates/pipelines on a cloud should behave the same way,
+set the mode and/or candidates once on the cloud itself and only override at specific
+call sites that need to differ (including opting all the way back out with `NONE`/`,`).
 
 #### Convert VM to Template
 

--- a/docs/jenkins-configuration.md
+++ b/docs/jenkins-configuration.md
@@ -82,6 +82,10 @@ Ticking this enables the following:
   Recommended for short-lived VMs as otherwise it takes longer to clone the disks than it does for anything else.
 * Enter Cluster, Resource Pool, Datastore, Folder, Customization Specification as required, this are settings how the clone will be created in vSphere.
 Enter "Resources" as default for "Resource Pool" if you haven't explicitly defined resource pools in vCenter.
+* Target Host, Host Selection Mode, Candidate Hosts (all optional, under "Advanced..."):
+control which ESXi host within the Cluster new clones are placed on.
+See ["Controlling which ESXi host a clone lands on"](#controlling-which-esxi-host-a-clone-lands-on) below for details and examples.
+Leaving these blank preserves the historical behaviour (vCenter's own default placement, unaffected by this feature).
 * Labels:
 You can use these labels to configure a job where it should be built.
 Use the label in the box "Restrict where this project can be run" in the job configuration.
@@ -137,6 +141,10 @@ Note that any such functionality is dependent on there being support for it in t
 This build step will clone an existing Template or VM to a new VM.
 Linked clones are optional.
 Cluster, Resource Pool, and Datastore can be specified.
+Under "Advanced...", Host, Host Selection Mode and Candidate Hosts can be used to control
+which ESXi host the clone is placed on - see
+["Controlling which ESXi host a clone lands on"](#controlling-which-esxi-host-a-clone-lands-on)
+below.
 
 #### Deploy VM from Template
 
@@ -144,6 +152,60 @@ This build step will create a VM from the specified template.
 The template must have at least one snapshot before it can be cloned.
 A linked clone may optionally be chosen.
 The new VM will be placed in the same folder and storage device as the original template, and will use the specified ResourcePool and Cluster.
+Under "Advanced...", Host, Host Selection Mode and Candidate Hosts can be used to control
+which ESXi host the clone is placed on - see
+["Controlling which ESXi host a clone lands on"](#controlling-which-esxi-host-a-clone-lands-on)
+below.
+
+#### Controlling which ESXi host a clone lands on
+
+By default (all three fields left blank), clones are placed wherever vCenter's own
+default placement logic decides - in practice, often the same host the source
+VM/template is registered on, which can unbalance load across a cluster over time.
+**This is unchanged from previous plugin versions**: nothing about existing jobs,
+pipelines, or templates changes unless you explicitly set one of these fields.
+
+Three independent, optional mechanisms are available, in order of precedence:
+
+1. **Host** (`host` on the build steps, `targetHost` on cloud templates) - pin the clone
+   to one named ESXi host. Always wins if set. Works on any vSphere edition/license and
+   any permission setup, including a service account restricted to a single host. Best
+   for small/test labs, or whenever you want full manual control.
+
+   *Example (build step):* `Host: esx-rack3-host07.example.com`
+
+2. **Host Selection Mode** (`hostSelectionMode`) - used only when "Host" is blank, this
+   lets the plugin pick automatically:
+   * `LEAST_LOADED` - the plugin reads current CPU/memory usage for each candidate host
+     and picks the least loaded one itself. No DRS license/feature is required, so this
+     works on Essentials/Standard editions or on a cluster with DRS turned off. It does
+     not know about VMware's own affinity/anti-affinity rules, HA reservations, or
+     storage placement policies - it is a simple, dependency-free heuristic, well suited
+     to quick/test setups or environments without a DRS license.
+   * `DRS_RECOMMENDED` - asks vCenter's own DRS engine for a placement recommendation,
+     restricted to the candidate hosts. This honours the cluster's real DRS/HA/affinity/
+     storage policies, but **requires DRS to be enabled and licensed on the cluster**
+     (vSphere Enterprise Plus, or an equivalent edition/license). If DRS is unavailable,
+     disabled, or gives no recommendation, the plugin automatically falls back to
+     `LEAST_LOADED` behaviour (logged as a warning) rather than failing the build. This
+     is the recommended choice for enterprise environments that already rely on DRS, so
+     that Jenkins agent placement follows the same policy as everything else.
+
+3. **Candidate Hosts** (`candidateHosts`) - an optional comma-separated allow-list, e.g.
+   `esx01.example.com, esx02.example.com, esx03.example.com`, that restricts what "Host
+   Selection Mode" is allowed to consider. Not every host visible in a cluster is
+   necessarily usable by the vCenter account running the connection - a vCenter admin
+   may restrict provisioning permission to a subset of hosts - so this is the mechanism
+   to keep automatic selection within permitted hosts. It is **not verified live**
+   against actual vCenter permissions: an incorrect entry, or a host the account cannot
+   actually write to, only surfaces as a vCenter-side error when a clone is attempted.
+   Leave blank to consider every (connected, non-maintenance-mode) host in the cluster.
+
+In short: pick "Host" for a fixed lab setup, `LEAST_LOADED` if you want basic load
+spreading without a DRS license, or `DRS_RECOMMENDED` if you're already on Enterprise
+Plus (or similar) and want placement to follow the same DRS policy as the rest of the
+cluster; use "Candidate Hosts" whenever the automation account can't write to every
+host vCenter shows you.
 
 #### Convert VM to Template
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -98,11 +98,21 @@ buildStep: [$class: 'Clone',
             customizationSpec: '',         // guest OS customization spec name (optional)
             useCurrentSnapshot: null,      // true = clone from current snapshot; false = don't use snapshot
             namedSnapshot: '',             // clone from this specific named snapshot (optional)
-            extraConfigParameters: [:]     // extra VMX key-value pairs to set on the new VM (optional)
+            extraConfigParameters: [:],    // extra VMX key-value pairs to set on the new VM (optional)
+            host: '',                      // (optional) pin the clone to this specific ESXi host; wins over hostSelectionMode
+            hostSelectionMode: '',         // (optional) '', 'LEAST_LOADED', or 'DRS_RECOMMENDED' - see below
+            candidateHosts: ''             // (optional) comma-separated allow-list restricting hostSelectionMode's candidates
            ]
 ```
 
 The `datastore` option can be useful if your templates live on different storage (slower/cheaper) than production VMs, so run-time instances should not appear "near" their origin.
+
+`host`, `hostSelectionMode` and `candidateHosts` are all optional and, left blank, behave
+exactly as before this feature was added (vCenter's own default placement). See
+["Controlling which ESXi host a clone lands on"](jenkins-configuration.md#controlling-which-esxi-host-a-clone-lands-on)
+for the full explanation of each mode and when to prefer one over another (it mostly
+comes down to whether your vSphere edition/license has DRS, and whether the account
+Jenkins connects with can write to every host in the cluster).
 
 The `useCurrentSnapshot` and `namedSnapshot` are mutually exclusive.
 
@@ -137,7 +147,10 @@ buildStep: [$class: 'Deploy',
             linkedClone: false,
             powerOn: false,
             timeoutInSeconds: 60,
-            customizationSpec: ''
+            customizationSpec: '',
+            host: '',                    // (optional) same meaning as on the Clone step
+            hostSelectionMode: '',        // (optional) '', 'LEAST_LOADED', or 'DRS_RECOMMENDED'
+            candidateHosts: ''            // (optional) comma-separated allow-list
            ]
 ```
 
@@ -359,6 +372,70 @@ vSphere(
 )
 echo "VM IP: ${env.VSPHERE_IP}"
 ```
+
+### Spread clones across a cluster instead of piling onto one host
+
+Without any of the fields below, every clone lands wherever vCenter's own default
+placement decides - in practice, often the same host the template is registered on.
+The `hostSelectionMode` field lets the plugin (or vCenter's own DRS) spread clones out
+instead.
+
+```groovy
+// No DRS license needed: the plugin ranks candidate hosts by current CPU/memory
+// usage itself and picks the least loaded one.
+vSphere(
+    serverName: 'my-vcenter',
+    buildStep: [$class: 'Clone',
+                sourceName: 'linux-template',
+                clone: "build-${env.BUILD_NUMBER}",
+                cluster: 'my-cluster',
+                resourcePool: 'Resources',
+                hostSelectionMode: 'LEAST_LOADED',
+                // Only consider hosts this service account can actually provision on:
+                candidateHosts: 'esx01.example.com, esx02.example.com, esx03.example.com',
+                powerOn: true]
+)
+```
+
+```groovy
+// If your cluster has DRS enabled and licensed (vSphere Enterprise Plus or
+// equivalent), you can defer to vCenter's own placement recommendation instead,
+// which also takes affinity/anti-affinity/HA/storage policies into account:
+vSphere(
+    serverName: 'my-vcenter',
+    buildStep: [$class: 'Clone',
+                sourceName: 'linux-template',
+                clone: "build-${env.BUILD_NUMBER}",
+                cluster: 'my-cluster',
+                resourcePool: 'Resources',
+                hostSelectionMode: 'DRS_RECOMMENDED',
+                candidateHosts: 'esx01.example.com, esx02.example.com, esx03.example.com',
+                powerOn: true]
+)
+// If DRS is unavailable/unlicensed/disabled on the cluster, this automatically
+// falls back to the same least-loaded-host behaviour as above (a warning is
+// logged), rather than failing the build.
+```
+
+```groovy
+// Or just pin every clone to one specific host, e.g. for a small/test lab:
+vSphere(
+    serverName: 'my-vcenter',
+    buildStep: [$class: 'Clone',
+                sourceName: 'linux-template',
+                clone: "build-${env.BUILD_NUMBER}",
+                cluster: 'my-cluster',
+                resourcePool: 'Resources',
+                host: 'esx-lab-01.example.com',
+                powerOn: true]
+)
+```
+
+See
+["Controlling which ESXi host a clone lands on"](jenkins-configuration.md#controlling-which-esxi-host-a-clone-lands-on)
+for the full explanation of these three fields, including why one deployment might
+prefer a different mode than another (VMware edition/license, whether DRS is enabled,
+and whether the automation account can write to every host).
 
 ### Full VM lifecycle
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -101,18 +101,23 @@ buildStep: [$class: 'Clone',
             extraConfigParameters: [:],    // extra VMX key-value pairs to set on the new VM (optional)
             host: '',                      // (optional) pin the clone to this specific ESXi host; wins over hostSelectionMode
             hostSelectionMode: '',         // (optional) '', 'LEAST_LOADED', or 'DRS_RECOMMENDED' - see below
-            candidateHosts: ''             // (optional) comma-separated allow-list restricting hostSelectionMode's candidates
+            hostSelectionCandidates: []             // (optional) allow-list restricting hostSelectionMode's candidates
            ]
 ```
 
 The `datastore` option can be useful if your templates live on different storage (slower/cheaper) than production VMs, so run-time instances should not appear "near" their origin.
 
-`host`, `hostSelectionMode` and `candidateHosts` are all optional and, left blank, behave
+`host`, `hostSelectionMode` and `hostSelectionCandidates` are all optional and, left blank, behave
 exactly as before this feature was added (vCenter's own default placement). See
 ["Controlling which ESXi host a clone lands on"](jenkins-configuration.md#controlling-which-esxi-host-a-clone-lands-on)
 for the full explanation of each mode and when to prefer one over another (it mostly
 comes down to whether your vSphere edition/license has DRS, and whether the account
 Jenkins connects with can write to every host in the cluster).
+
+`hostSelectionCandidates` takes a list (`['esx01.example.com', 'esx02.example.com']`). If
+you'd rather build a comma-separated string, set `hostSelectionCandidatesAsString` instead
+(`'esx01.example.com, esx02.example.com'`) - use only one of the two; both end up stored
+the same way.
 
 The `useCurrentSnapshot` and `namedSnapshot` are mutually exclusive.
 
@@ -150,7 +155,7 @@ buildStep: [$class: 'Deploy',
             customizationSpec: '',
             host: '',                    // (optional) same meaning as on the Clone step
             hostSelectionMode: '',        // (optional) '', 'LEAST_LOADED', or 'DRS_RECOMMENDED'
-            candidateHosts: ''            // (optional) comma-separated allow-list
+            hostSelectionCandidates: []            // (optional) allow-list, or use hostSelectionCandidatesAsString for a CSV string
            ]
 ```
 
@@ -391,8 +396,11 @@ vSphere(
                 cluster: 'my-cluster',
                 resourcePool: 'Resources',
                 hostSelectionMode: 'LEAST_LOADED',
-                // Only consider hosts this service account can actually provision on:
-                candidateHosts: 'esx01.example.com, esx02.example.com, esx03.example.com',
+                // Only consider hosts this service account can actually provision on.
+                // A list, or a comma-separated string via hostSelectionCandidatesAsString,
+                // both work equally well:
+                hostSelectionCandidates: ['esx01.example.com', 'esx02.example.com', 'esx03.example.com'],
+                // hostSelectionCandidatesAsString: 'esx01.example.com, esx02.example.com, esx03.example.com',
                 powerOn: true]
 )
 ```
@@ -409,7 +417,7 @@ vSphere(
                 cluster: 'my-cluster',
                 resourcePool: 'Resources',
                 hostSelectionMode: 'DRS_RECOMMENDED',
-                candidateHosts: 'esx01.example.com, esx02.example.com, esx03.example.com',
+                hostSelectionCandidates: ['esx01.example.com', 'esx02.example.com', 'esx03.example.com'],
                 powerOn: true]
 )
 // If DRS is unavailable/unlicensed/disabled on the cluster, this automatically

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -100,24 +100,34 @@ buildStep: [$class: 'Clone',
             namedSnapshot: '',             // clone from this specific named snapshot (optional)
             extraConfigParameters: [:],    // extra VMX key-value pairs to set on the new VM (optional)
             host: '',                      // (optional) pin the clone to this specific ESXi host; wins over hostSelectionMode
-            hostSelectionMode: '',         // (optional) '', 'LEAST_LOADED', or 'DRS_RECOMMENDED' - see below
+            hostSelectionMode: '',         // (optional) '', 'NONE', 'LEAST_LOADED', or 'DRS_RECOMMENDED' - see below
             hostSelectionCandidates: []             // (optional) allow-list restricting hostSelectionMode's candidates
            ]
 ```
 
 The `datastore` option can be useful if your templates live on different storage (slower/cheaper) than production VMs, so run-time instances should not appear "near" their origin.
 
-`host`, `hostSelectionMode` and `hostSelectionCandidates` are all optional and, left blank, behave
-exactly as before this feature was added (vCenter's own default placement). See
+`host`, `hostSelectionMode` and `hostSelectionCandidates` are all optional. Left blank,
+`hostSelectionMode`/`hostSelectionCandidates` **inherit whatever default is configured on
+the vSphere Cloud itself** (see
+["vSphere Cloud Configuration"](jenkins-configuration.md#vsphere-cloud-configuration));
+if the cloud has no default either, this is unchanged legacy behaviour (vCenter's own
+default placement). See
 ["Controlling which ESXi host a clone lands on"](jenkins-configuration.md#controlling-which-esxi-host-a-clone-lands-on)
 for the full explanation of each mode and when to prefer one over another (it mostly
 comes down to whether your vSphere edition/license has DRS, and whether the account
 Jenkins connects with can write to every host in the cluster).
 
+Set `hostSelectionMode: 'NONE'` to explicitly disable host selection for just this step,
+even if the cloud has a default mode configured - the cloud-wide default only applies
+when this field is left blank, not set to `'NONE'`.
+
 `hostSelectionCandidates` takes a list (`['esx01.example.com', 'esx02.example.com']`). If
 you'd rather build a comma-separated string, set `hostSelectionCandidatesAsString` instead
 (`'esx01.example.com, esx02.example.com'`) - use only one of the two; both end up stored
-the same way.
+the same way. Leaving both blank inherits the cloud's default candidate list; setting
+`hostSelectionCandidatesAsString: ','` (a single comma) explicitly overrides to "no
+restriction" for just this step, the same way `'NONE'` does for the mode.
 
 The `useCurrentSnapshot` and `namedSnapshot` are mutually exclusive.
 
@@ -435,6 +445,37 @@ vSphere(
                 cluster: 'my-cluster',
                 resourcePool: 'Resources',
                 host: 'esx-lab-01.example.com',
+                powerOn: true]
+)
+```
+
+```groovy
+// If most pipelines against 'my-vcenter' should use the same placement policy, set it
+// once on the vSphere Cloud itself (Jenkins "Configure System" -> Advanced...) instead
+// of repeating hostSelectionMode/hostSelectionCandidates on every call. A step can then
+// leave both blank to inherit that cloud-wide default:
+vSphere(
+    serverName: 'my-vcenter',
+    buildStep: [$class: 'Clone',
+                sourceName: 'linux-template',
+                clone: "build-${env.BUILD_NUMBER}",
+                cluster: 'my-cluster',
+                resourcePool: 'Resources',
+                // hostSelectionMode and hostSelectionCandidates both left unset here:
+                // this step inherits whatever the cloud has configured as its default.
+                powerOn: true]
+)
+
+// ...and a step that needs to keep the old, unrestricted placement behaviour even
+// though the cloud has a default configured can opt out explicitly:
+vSphere(
+    serverName: 'my-vcenter',
+    buildStep: [$class: 'Clone',
+                sourceName: 'special-template',
+                clone: "special-${env.BUILD_NUMBER}",
+                cluster: 'my-cluster',
+                resourcePool: 'Resources',
+                hostSelectionMode: 'NONE', // overrides the cloud's default for this step only
                 powerOn: true]
 )
 ```

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -15,6 +15,7 @@ import hudson.slaves.NodeProvisioner.PlannedNode;
 import hudson.slaves.SlaveComputer;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.StreamTaskListener;
 import jenkins.model.Jenkins;
 import jenkins.slaves.iterators.api.NodeIterator;
@@ -34,7 +35,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -76,6 +79,19 @@ public class vSphereCloud extends Cloud {
     private boolean maintenanceMode = false;
     /** MOTD-style message shown to consumers (build console / agent launch log) while this cloud is in maintenance mode. */
     private String maintenanceMessage = "";
+
+    /**
+     * Default {@code hostSelectionMode} for every template/build-step using this cloud,
+     * unless that call site sets its own (or opts out with "NONE"). Null/blank means no
+     * default - unchanged legacy behaviour if nothing sets a mode anywhere.
+     */
+    private String hostSelectionMode;
+    /**
+     * Default {@code hostSelectionCandidates} allow-list for every template/build-step
+     * using this cloud, unless that call site sets its own (including an explicit empty
+     * override). Null means no default - every host is a candidate unless overridden.
+     */
+    private Set<String> hostSelectionCandidates;
 
     private transient int currentOnlineSlaveCount = 0;
     private transient ConcurrentHashMap<String, String> currentOnline;
@@ -299,6 +315,36 @@ public class vSphereCloud extends Cloud {
     @DataBoundSetter
     public void setMaintenanceMessage(String maintenanceMessage) {
         this.maintenanceMessage = maintenanceMessage;
+    }
+
+    /** Default {@code hostSelectionMode} for templates/build-steps that leave their own blank. */
+    public String getHostSelectionMode() {
+        return hostSelectionMode;
+    }
+
+    @DataBoundSetter
+    public void setHostSelectionMode(String hostSelectionMode) {
+        this.hostSelectionMode = hostSelectionMode;
+    }
+
+    /** Default {@code hostSelectionCandidates} for templates/build-steps that leave their own unset. */
+    public Set<String> getHostSelectionCandidates() {
+        return hostSelectionCandidates;
+    }
+
+    @DataBoundSetter
+    public void setHostSelectionCandidates(Collection<String> hostSelectionCandidates) {
+        this.hostSelectionCandidates = hostSelectionCandidates == null ? null : new LinkedHashSet<>(hostSelectionCandidates);
+    }
+
+    /** For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain string. */
+    public String getHostSelectionCandidatesAsString() {
+        return VSphereHostSelection.toAllowListString(hostSelectionCandidates);
+    }
+
+    @DataBoundSetter
+    public void setHostSelectionCandidatesAsString(String hostSelectionCandidatesCsv) {
+        this.hostSelectionCandidates = VSphereHostSelection.parseAllowListOrNull(hostSelectionCandidatesCsv);
     }
 
     /** Shuts down any running pool and clears the reference so it is recreated on next use. */
@@ -890,6 +936,14 @@ public class vSphereCloud extends Cloud {
                 return FormValidation.warning("This cloud's VM operations will block (and log a message to consumers) until maintenance mode is turned off.");
             }
             return FormValidation.ok();
+        }
+
+        public ListBoxModel doFillHostSelectionModeItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("(none - no cloud-wide default)", "");
+            items.add("Least loaded host (CPU/memory, no DRS license required)", "LEAST_LOADED");
+            items.add("DRS recommendation (requires DRS enabled + licensed on the cluster)", "DRS_RECOMMENDED");
+            return items;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -321,14 +321,19 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         this.hostSelectionCandidates = hostSelectionCandidates == null ? null : new LinkedHashSet<>(hostSelectionCandidates);
     }
 
-    /** For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain string. */
+    /**
+     * For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain
+     * string. Blank means "inherit the cloud's default candidate list" (see {@link
+     * vSphereCloud#getHostSelectionCandidates()}); a single comma explicitly overrides
+     * to "no restriction at this call site" - see {@link VSphereHostSelection#toAllowListString}.
+     */
     public String getHostSelectionCandidatesAsString() {
-        return VSphereHostSelection.toCsv(this.hostSelectionCandidates);
+        return VSphereHostSelection.toAllowListString(this.hostSelectionCandidates);
     }
 
     @DataBoundSetter
     public void setHostSelectionCandidatesAsString(String hostSelectionCandidatesCsv) {
-        this.hostSelectionCandidates = VSphereHostSelection.parseAllowList(hostSelectionCandidatesCsv);
+        this.hostSelectionCandidates = VSphereHostSelection.parseAllowListOrNull(hostSelectionCandidatesCsv);
     }
 
     /**
@@ -471,8 +476,13 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             useCurrentSnapshot = false;
             snapshotToUse = null;
         }
+        final vSphereCloud sourceCloud = getParent();
+        final String cloudDefaultHostSelectionMode = sourceCloud != null ? sourceCloud.getHostSelectionMode() : null;
+        final Set<String> cloudDefaultHostSelectionCandidates = sourceCloud != null ? sourceCloud.getHostSelectionCandidates() : null;
+        final String resolvedHostSelectionMode = VSphereHostSelection.resolveMode(cloudDefaultHostSelectionMode, this.hostSelectionMode);
+        final Set<String> resolvedHostSelectionCandidates = VSphereHostSelection.resolveCandidates(cloudDefaultHostSelectionCandidates, this.hostSelectionCandidates);
         try {
-            vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, this.folder, useCurrentSnapshot, snapshotToUse, POWER_ON, resolvedExtraConfigParameters, this.customizationSpec, this.targetHost, this.hostSelectionMode, this.hostSelectionCandidates, logger);
+            vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, this.folder, useCurrentSnapshot, snapshotToUse, POWER_ON, resolvedExtraConfigParameters, this.customizationSpec, this.targetHost, resolvedHostSelectionMode, resolvedHostSelectionCandidates, logger);
             LOGGER.log(Level.FINE, "Created new VM {0} from image {1}", new Object[]{ cloneName, this.masterImageName });
         } catch (VSphereDuplicateException ex) {
             final String vmJenkinsUrl = findWhichJenkinsThisVMBelongsTo(vSphere, cloneName);
@@ -619,7 +629,8 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
 
         public ListBoxModel doFillHostSelectionModeItems() {
             ListBoxModel items = new ListBoxModel();
-            items.add("(none - vCenter's own default placement)", "");
+            items.add("(none - inherit the cloud's default)", "");
+            items.add("Explicitly none (override the cloud's default)", VSphereHostSelection.HOST_SELECTION_MODE_NONE);
             items.add("Least loaded host (CPU/memory, no DRS license required)", "LEAST_LOADED");
             items.add("DRS recommendation (requires DRS enabled + licensed on the cluster)", "DRS_RECOMMENDED");
             return items;

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -37,6 +37,7 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.RetentionStrategy;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -64,10 +65,12 @@ import org.jenkinsci.plugins.vsphere.builders.Messages;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereDuplicateException;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;
+import org.jenkinsci.plugins.vsphere.tools.VSphereHostSelection;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -114,6 +117,10 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
     private final boolean saveFailure;
     private final String targetResourcePool;
     private final String targetHost;
+    /** Optional; one of "", "LEAST_LOADED", "DRS_RECOMMENDED". Ignored when {@code targetHost} is set. */
+    private String hostSelectionMode;
+    /** Optional comma-separated allow-list restricting {@code hostSelectionMode}'s candidates. */
+    private String candidateHosts;
     /**
      * Credentials from old configuration format. Credentials are now in the
      * {@link #launcher} configuration
@@ -284,6 +291,24 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         return this.targetHost;
     }
 
+    public String getHostSelectionMode() {
+        return this.hostSelectionMode;
+    }
+
+    @DataBoundSetter
+    public void setHostSelectionMode(String hostSelectionMode) {
+        this.hostSelectionMode = hostSelectionMode;
+    }
+
+    public String getCandidateHosts() {
+        return this.candidateHosts;
+    }
+
+    @DataBoundSetter
+    public void setCandidateHosts(String candidateHosts) {
+        this.candidateHosts = candidateHosts;
+    }
+
     /**
      * Gets the old (deprecated) credentialsId field.
      * 
@@ -425,7 +450,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             snapshotToUse = null;
         }
         try {
-            vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, this.folder, useCurrentSnapshot, snapshotToUse, POWER_ON, resolvedExtraConfigParameters, this.customizationSpec, logger);
+            vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, this.folder, useCurrentSnapshot, snapshotToUse, POWER_ON, resolvedExtraConfigParameters, this.customizationSpec, this.targetHost, this.hostSelectionMode, this.candidateHosts, logger);
             LOGGER.log(Level.FINE, "Created new VM {0} from image {1}", new Object[]{ cloneName, this.masterImageName });
         } catch (VSphereDuplicateException ex) {
             final String vmJenkinsUrl = findWhichJenkinsThisVMBelongsTo(vSphere, cloneName);
@@ -570,13 +595,22 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             return FormValidation.validateNonNegativeInteger(launchDelay);
         }
 
+        public ListBoxModel doFillHostSelectionModeItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("(none - vCenter's own default placement)", "");
+            items.add("Least loaded host (CPU/memory, no DRS license required)", "LEAST_LOADED");
+            items.add("DRS recommendation (requires DRS enabled + licensed on the cluster)", "DRS_RECOMMENDED");
+            return items;
+        }
+
         @RequirePOST
         public FormValidation doTestCloneParameters(@AncestorInPath AbstractFolder<?> containingFolderOrNull,
                 @QueryParameter String vsHost,
                 @QueryParameter boolean allowUntrustedCertificate,
                 @QueryParameter String credentialsId, @QueryParameter String masterImageName,
                 @QueryParameter boolean linkedClone, @QueryParameter boolean useSnapshot,
-                @QueryParameter String snapshotName) {
+                @QueryParameter String snapshotName,
+                @QueryParameter String targetHost, @QueryParameter String candidateHosts) {
             throwUnlessUserHasPermissionToConfigureCloud(containingFolderOrNull);
             try {
                 final VSphereConnectionConfig config = new VSphereConnectionConfig(vsHost, allowUntrustedCertificate, credentialsId);
@@ -605,6 +639,19 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                             return FormValidation.warning("vSphere doesn't like creating linked clones without a snapshot");
                         }
                     }
+
+                    if (targetHost != null && !targetHost.isEmpty() && !vsphere.hostExists(targetHost)) {
+                        return FormValidation.error(Messages.validation_notFound("host \"" + targetHost + "\""));
+                    }
+
+                    if (candidateHosts != null && !candidateHosts.isEmpty()) {
+                        for (String candidateHost : VSphereHostSelection.parseAllowList(candidateHosts)) {
+                            if (!vsphere.hostExists(candidateHost)) {
+                                return FormValidation.error("Candidate host \"" + candidateHost + "\" was not found.");
+                            }
+                        }
+                    }
+
                     return FormValidation.ok(Messages.validation_success());
                 } finally {
                     vsphere.disconnect();

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudSlaveTemplate.java
@@ -43,8 +43,10 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -119,8 +121,8 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
     private final String targetHost;
     /** Optional; one of "", "LEAST_LOADED", "DRS_RECOMMENDED". Ignored when {@code targetHost} is set. */
     private String hostSelectionMode;
-    /** Optional comma-separated allow-list restricting {@code hostSelectionMode}'s candidates. */
-    private String candidateHosts;
+    /** Optional allow-list restricting {@code hostSelectionMode}'s candidates. */
+    private Set<String> hostSelectionCandidates;
     /**
      * Credentials from old configuration format. Credentials are now in the
      * {@link #launcher} configuration
@@ -300,13 +302,33 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
         this.hostSelectionMode = hostSelectionMode;
     }
 
-    public String getCandidateHosts() {
-        return this.candidateHosts;
+    /** Canonical form, for pipeline/API/JCasC consumers. */
+    public Set<String> getHostSelectionCandidates() {
+        return this.hostSelectionCandidates;
+    }
+
+    /**
+     * Takes a flat list of individual host names - the natural shape for a pipeline or
+     * JCasC YAML caller that already has one. See {@link #setHostSelectionCandidatesAsString}
+     * for the comma-separated-string equivalent (used by the classic UI textbox). Both
+     * are kept as separate, concretely-typed properties rather than one that accepts
+     * either shape: Jenkins' JCasC introspection resolves exactly one configurator per
+     * property type, so a single {@code Object}-typed (or overloaded) setter is not
+     * reliably usable from YAML, even though pipeline's looser binding tolerates it.
+     */
+    @DataBoundSetter
+    public void setHostSelectionCandidates(Collection<String> hostSelectionCandidates) {
+        this.hostSelectionCandidates = hostSelectionCandidates == null ? null : new LinkedHashSet<>(hostSelectionCandidates);
+    }
+
+    /** For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain string. */
+    public String getHostSelectionCandidatesAsString() {
+        return VSphereHostSelection.toCsv(this.hostSelectionCandidates);
     }
 
     @DataBoundSetter
-    public void setCandidateHosts(String candidateHosts) {
-        this.candidateHosts = candidateHosts;
+    public void setHostSelectionCandidatesAsString(String hostSelectionCandidatesCsv) {
+        this.hostSelectionCandidates = VSphereHostSelection.parseAllowList(hostSelectionCandidatesCsv);
     }
 
     /**
@@ -450,7 +472,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
             snapshotToUse = null;
         }
         try {
-            vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, this.folder, useCurrentSnapshot, snapshotToUse, POWER_ON, resolvedExtraConfigParameters, this.customizationSpec, this.targetHost, this.hostSelectionMode, this.candidateHosts, logger);
+            vSphere.cloneOrDeployVm(cloneName, this.masterImageName, this.linkedClone, this.resourcePool, this.cluster, this.datastore, this.folder, useCurrentSnapshot, snapshotToUse, POWER_ON, resolvedExtraConfigParameters, this.customizationSpec, this.targetHost, this.hostSelectionMode, this.hostSelectionCandidates, logger);
             LOGGER.log(Level.FINE, "Created new VM {0} from image {1}", new Object[]{ cloneName, this.masterImageName });
         } catch (VSphereDuplicateException ex) {
             final String vmJenkinsUrl = findWhichJenkinsThisVMBelongsTo(vSphere, cloneName);
@@ -610,7 +632,7 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                 @QueryParameter String credentialsId, @QueryParameter String masterImageName,
                 @QueryParameter boolean linkedClone, @QueryParameter boolean useSnapshot,
                 @QueryParameter String snapshotName,
-                @QueryParameter String targetHost, @QueryParameter String candidateHosts) {
+                @QueryParameter String targetHost, @QueryParameter String hostSelectionCandidatesAsString) {
             throwUnlessUserHasPermissionToConfigureCloud(containingFolderOrNull);
             try {
                 final VSphereConnectionConfig config = new VSphereConnectionConfig(vsHost, allowUntrustedCertificate, credentialsId);
@@ -644,8 +666,8 @@ public class vSphereCloudSlaveTemplate implements Describable<vSphereCloudSlaveT
                         return FormValidation.error(Messages.validation_notFound("host \"" + targetHost + "\""));
                     }
 
-                    if (candidateHosts != null && !candidateHosts.isEmpty()) {
-                        for (String candidateHost : VSphereHostSelection.parseAllowList(candidateHosts)) {
+                    if (hostSelectionCandidatesAsString != null && !hostSelectionCandidatesAsString.isEmpty()) {
+                        for (String candidateHost : VSphereHostSelection.parseAllowList(hostSelectionCandidatesAsString)) {
                             if (!vsphere.hostExists(candidateHost)) {
                                 return FormValidation.error("Candidate host \"" + candidateHost + "\" was not found.");
                             }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStep.java
@@ -37,12 +37,30 @@ public abstract class VSphereBuildStep implements Describable<VSphereBuildStep>,
 
 	protected VSphere vsphere;
 
+	/**
+	 * The {@link vSphereCloud} this step is currently running against, set by whatever
+	 * resolves {@link #vsphere} for this run (currently only {@link VSphereBuildStepContainer}).
+	 * Used to fall back to cloud-level defaults (e.g. {@code hostSelectionMode}) for
+	 * fields a subclass leaves unset. May be null if a caller never sets it (e.g. a
+	 * build step invoked directly, bypassing the container), in which case there is
+	 * simply no cloud-level default to fall back to.
+	 */
+	protected vSphereCloud sourceCloud;
+
 	public VSphere getVsphere() {
 		return vsphere;
 	}
 
 	public void setVsphere(VSphere vsphere) {
 		this.vsphere = vsphere;
+	}
+
+	public vSphereCloud getSourceCloud() {
+		return sourceCloud;
+	}
+
+	public void setSourceCloud(vSphereCloud sourceCloud) {
+		this.sourceCloud = sourceCloud;
 	}
 
 	public String getIP() {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/VSphereBuildStepContainer.java
@@ -96,9 +96,11 @@ public class VSphereBuildStepContainer extends Builder implements SimpleBuildSte
             // reconfigured Cloud with a brand-new instance (e.g. the admin toggling
             // maintenance mode back off while we were blocked), so the instance we just
             // waited on may no longer be the live one by the time waiting is done.
-            vsphere = resolveCloud(expandedServerName, jobName).vSphereInstance();
+            final vSphereCloud resolvedCloud = resolveCloud(expandedServerName, jobName);
+            vsphere = resolvedCloud.vSphereInstance();
 
             buildStep.setVsphere(vsphere);
+            buildStep.setSourceCloud(resolvedCloud);
             if (run instanceof AbstractBuild) {
                 buildStep.perform(((AbstractBuild) run), launcher, (BuildListener) listener);
             } else {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import org.jenkinsci.plugins.vSphereCloud;
 import org.jenkinsci.plugins.vsphere.VSphereBuildStep;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;
@@ -220,14 +221,20 @@ public class Clone extends VSphereBuildStep {
         this.hostSelectionCandidates = hostSelectionCandidates == null ? null : new LinkedHashSet<>(hostSelectionCandidates);
     }
 
-    /** For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain string. */
+    /**
+     * For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain
+     * string. Blank means "inherit the cloud's default candidate list" (see {@link
+     * org.jenkinsci.plugins.vSphereCloud#getHostSelectionCandidates()}); a single comma
+     * explicitly overrides to "no restriction at this call site" - see {@link
+     * VSphereHostSelection#toAllowListString}.
+     */
     public String getHostSelectionCandidatesAsString() {
-        return VSphereHostSelection.toCsv(hostSelectionCandidates);
+        return VSphereHostSelection.toAllowListString(hostSelectionCandidates);
     }
 
     @DataBoundSetter
     public void setHostSelectionCandidatesAsString(String hostSelectionCandidatesCsv) {
-        this.hostSelectionCandidates = VSphereHostSelection.parseAllowList(hostSelectionCandidatesCsv);
+        this.hostSelectionCandidates = VSphereHostSelection.parseAllowListOrNull(hostSelectionCandidatesCsv);
     }
 
     @Override
@@ -322,10 +329,16 @@ public class Clone extends VSphereBuildStep {
             expandedExtraConfigParameters = null;
         }
 
+        final vSphereCloud sourceCloud = getSourceCloud();
+        final String cloudDefaultHostSelectionMode = sourceCloud != null ? sourceCloud.getHostSelectionMode() : null;
+        final Set<String> cloudDefaultHostSelectionCandidates = sourceCloud != null ? sourceCloud.getHostSelectionCandidates() : null;
+        final String resolvedHostSelectionMode = VSphereHostSelection.resolveMode(cloudDefaultHostSelectionMode, hostSelectionMode);
+        final Set<String> resolvedHostSelectionCandidates = VSphereHostSelection.resolveCandidates(cloudDefaultHostSelectionCandidates, expandedHostSelectionCandidates);
+
         vsphere.cloneOrDeployVm(expandedClone, expandedSource, linkedClone, expandedResourcePool, expandedCluster,
                 expandedDatastore, expandedFolder, this.isUseCurrentSnapshot(), expandedNamedSnapshot,
                 powerOn, expandedExtraConfigParameters, expandedCustomizationSpec,
-                expandedHost, hostSelectionMode, expandedHostSelectionCandidates, jLogger);
+                expandedHost, resolvedHostSelectionMode, resolvedHostSelectionCandidates, jLogger);
 
         final int timeoutInSecondsForGetIp = getTimeoutInSeconds();
         if (powerOn && timeoutInSecondsForGetIp>0) {
@@ -407,7 +420,8 @@ public class Clone extends VSphereBuildStep {
 
         public ListBoxModel doFillHostSelectionModeItems() {
             ListBoxModel items = new ListBoxModel();
-            items.add("(none - vCenter's own default placement)", "");
+            items.add("(none - inherit the cloud's default)", "");
+            items.add("Explicitly none (override the cloud's default)", VSphereHostSelection.HOST_SELECTION_MODE_NONE);
             items.add("Least loaded host (CPU/memory, no DRS license required)", "LEAST_LOADED");
             items.add("DRS recommendation (requires DRS enabled + licensed on the cluster)", "DRS_RECOMMENDED");
             return items;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -23,6 +23,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -36,9 +37,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.plugins.vsphere.VSphereBuildStep;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;
+import org.jenkinsci.plugins.vsphere.tools.VSphereHostSelection;
 import org.jenkinsci.plugins.vsphere.tools.VSphereLogger;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -69,6 +72,13 @@ public class Clone extends VSphereBuildStep {
      *  conflicts with {@code #useCurrentSnapshot}. Is {@code null} by default. */
     private final String namedSnapshot;
     private final Map<String, String> extraConfigParameters;
+
+    /** Optional; unset means unchanged legacy behaviour (vCenter's own default placement). */
+    private String host;
+    /** Optional; one of "", "LEAST_LOADED", "DRS_RECOMMENDED". Ignored when {@code host} is set. */
+    private String hostSelectionMode;
+    /** Optional comma-separated allow-list restricting {@code hostSelectionMode}'s candidates. */
+    private String candidateHosts;
 
     @DataBoundConstructor
     public Clone(String sourceName, String clone, boolean linkedClone,
@@ -170,6 +180,33 @@ public class Clone extends VSphereBuildStep {
         return extraConfigParameters;
     }
 
+    public String getHost() {
+        return host;
+    }
+
+    @DataBoundSetter
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getHostSelectionMode() {
+        return hostSelectionMode;
+    }
+
+    @DataBoundSetter
+    public void setHostSelectionMode(String hostSelectionMode) {
+        this.hostSelectionMode = hostSelectionMode;
+    }
+
+    public String getCandidateHosts() {
+        return candidateHosts;
+    }
+
+    @DataBoundSetter
+    public void setCandidateHosts(String candidateHosts) {
+        this.candidateHosts = candidateHosts;
+    }
+
     @Override
     public void perform(@NonNull Run<?, ?> run, @NonNull FilePath filePath, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
         try {
@@ -215,6 +252,8 @@ public class Clone extends VSphereBuildStep {
         String expandedResourcePool = resourcePool;
         String expandedCustomizationSpec = customizationSpec;
         String expandedNamedSnapshot = namedSnapshot;
+        String expandedHost = host;
+        String expandedCandidateHosts = candidateHosts;
         Map<String, String> expandedExtraConfigParameters;
         EnvVars env;
         try {
@@ -235,6 +274,12 @@ public class Clone extends VSphereBuildStep {
             if (namedSnapshot != null) {
                 expandedNamedSnapshot = env.expand(namedSnapshot);
             }
+            if (host != null) {
+                expandedHost = env.expand(host);
+            }
+            if (candidateHosts != null) {
+                expandedCandidateHosts = env.expand(candidateHosts);
+            }
         }
 
         if (extraConfigParameters != null && !(extraConfigParameters.isEmpty())) {
@@ -253,7 +298,8 @@ public class Clone extends VSphereBuildStep {
 
         vsphere.cloneOrDeployVm(expandedClone, expandedSource, linkedClone, expandedResourcePool, expandedCluster,
                 expandedDatastore, expandedFolder, this.isUseCurrentSnapshot(), expandedNamedSnapshot,
-                powerOn, expandedExtraConfigParameters, expandedCustomizationSpec, jLogger);
+                powerOn, expandedExtraConfigParameters, expandedCustomizationSpec,
+                expandedHost, hostSelectionMode, expandedCandidateHosts, jLogger);
 
         final int timeoutInSecondsForGetIp = getTimeoutInSeconds();
         if (powerOn && timeoutInSecondsForGetIp>0) {
@@ -333,6 +379,14 @@ public class Clone extends VSphereBuildStep {
             return FormValidation.ok();
         }
 
+        public ListBoxModel doFillHostSelectionModeItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("(none - vCenter's own default placement)", "");
+            items.add("Least loaded host (CPU/memory, no DRS license required)", "LEAST_LOADED");
+            items.add("DRS recommendation (requires DRS enabled + licensed on the cluster)", "DRS_RECOMMENDED");
+            return items;
+        }
+
         public FormValidation doCheckTimeoutInSeconds(@QueryParameter String value) {
             return FormValidation.validateNonNegativeInteger(value);
         }
@@ -345,7 +399,9 @@ public class Clone extends VSphereBuildStep {
                                          @QueryParameter String customizationSpec,
                                          @QueryParameter Boolean linkedClone,
                                          @QueryParameter Boolean useCurrentSnapshot,
-                                         @QueryParameter String namedSnapshot) {
+                                         @QueryParameter String namedSnapshot,
+                                         @QueryParameter String host,
+                                         @QueryParameter String candidateHosts) {
             // TODO? @QueryParameter Map<String, String> extraConfigParameters
             throwUnlessUserHasPermissionToConfigureJob(context);
             VSphere vsphere = null;
@@ -387,6 +443,18 @@ public class Clone extends VSphereBuildStep {
                 if(customizationSpec != null && customizationSpec.length() > 0 &&
                         vsphere.getCustomizationSpecByName(customizationSpec) == null) {
                     return FormValidation.error(Messages.validation_notFound("customizationSpec"));
+                }
+
+                if (host != null && !host.isEmpty() && !vsphere.hostExists(host)) {
+                    return FormValidation.error(Messages.validation_notFound("host"));
+                }
+
+                if (candidateHosts != null && !candidateHosts.isEmpty()) {
+                    for (String candidateHost : VSphereHostSelection.parseAllowList(candidateHosts)) {
+                        if (!vsphere.hostExists(candidateHost)) {
+                            return FormValidation.error("Candidate host \"" + candidateHost + "\" was not found.");
+                        }
+                    }
                 }
 
                 return FormValidation.ok(Messages.validation_success());

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Clone.java
@@ -29,8 +29,11 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -77,8 +80,8 @@ public class Clone extends VSphereBuildStep {
     private String host;
     /** Optional; one of "", "LEAST_LOADED", "DRS_RECOMMENDED". Ignored when {@code host} is set. */
     private String hostSelectionMode;
-    /** Optional comma-separated allow-list restricting {@code hostSelectionMode}'s candidates. */
-    private String candidateHosts;
+    /** Optional allow-list restricting {@code hostSelectionMode}'s candidates. */
+    private Set<String> hostSelectionCandidates;
 
     @DataBoundConstructor
     public Clone(String sourceName, String clone, boolean linkedClone,
@@ -198,13 +201,33 @@ public class Clone extends VSphereBuildStep {
         this.hostSelectionMode = hostSelectionMode;
     }
 
-    public String getCandidateHosts() {
-        return candidateHosts;
+    /** Canonical form, for pipeline/API/JCasC consumers. */
+    public Set<String> getHostSelectionCandidates() {
+        return hostSelectionCandidates;
+    }
+
+    /**
+     * Takes a flat list of individual host names - the natural shape for a pipeline or
+     * JCasC YAML caller that already has one. See {@link #setHostSelectionCandidatesAsString}
+     * for the comma-separated-string equivalent (used by the classic UI textbox). Both
+     * are kept as separate, concretely-typed properties rather than one that accepts
+     * either shape: Jenkins' JCasC introspection resolves exactly one configurator per
+     * property type, so a single {@code Object}-typed (or overloaded) setter is not
+     * reliably usable from YAML, even though pipeline's looser binding tolerates it.
+     */
+    @DataBoundSetter
+    public void setHostSelectionCandidates(Collection<String> hostSelectionCandidates) {
+        this.hostSelectionCandidates = hostSelectionCandidates == null ? null : new LinkedHashSet<>(hostSelectionCandidates);
+    }
+
+    /** For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain string. */
+    public String getHostSelectionCandidatesAsString() {
+        return VSphereHostSelection.toCsv(hostSelectionCandidates);
     }
 
     @DataBoundSetter
-    public void setCandidateHosts(String candidateHosts) {
-        this.candidateHosts = candidateHosts;
+    public void setHostSelectionCandidatesAsString(String hostSelectionCandidatesCsv) {
+        this.hostSelectionCandidates = VSphereHostSelection.parseAllowList(hostSelectionCandidatesCsv);
     }
 
     @Override
@@ -253,7 +276,7 @@ public class Clone extends VSphereBuildStep {
         String expandedCustomizationSpec = customizationSpec;
         String expandedNamedSnapshot = namedSnapshot;
         String expandedHost = host;
-        String expandedCandidateHosts = candidateHosts;
+        Set<String> expandedHostSelectionCandidates = hostSelectionCandidates;
         Map<String, String> expandedExtraConfigParameters;
         EnvVars env;
         try {
@@ -277,8 +300,11 @@ public class Clone extends VSphereBuildStep {
             if (host != null) {
                 expandedHost = env.expand(host);
             }
-            if (candidateHosts != null) {
-                expandedCandidateHosts = env.expand(candidateHosts);
+            if (hostSelectionCandidates != null) {
+                expandedHostSelectionCandidates = new LinkedHashSet<>();
+                for (String candidateHost : hostSelectionCandidates) {
+                    expandedHostSelectionCandidates.add(env.expand(candidateHost));
+                }
             }
         }
 
@@ -299,7 +325,7 @@ public class Clone extends VSphereBuildStep {
         vsphere.cloneOrDeployVm(expandedClone, expandedSource, linkedClone, expandedResourcePool, expandedCluster,
                 expandedDatastore, expandedFolder, this.isUseCurrentSnapshot(), expandedNamedSnapshot,
                 powerOn, expandedExtraConfigParameters, expandedCustomizationSpec,
-                expandedHost, hostSelectionMode, expandedCandidateHosts, jLogger);
+                expandedHost, hostSelectionMode, expandedHostSelectionCandidates, jLogger);
 
         final int timeoutInSecondsForGetIp = getTimeoutInSeconds();
         if (powerOn && timeoutInSecondsForGetIp>0) {
@@ -401,7 +427,7 @@ public class Clone extends VSphereBuildStep {
                                          @QueryParameter Boolean useCurrentSnapshot,
                                          @QueryParameter String namedSnapshot,
                                          @QueryParameter String host,
-                                         @QueryParameter String candidateHosts) {
+                                         @QueryParameter String hostSelectionCandidatesAsString) {
             // TODO? @QueryParameter Map<String, String> extraConfigParameters
             throwUnlessUserHasPermissionToConfigureJob(context);
             VSphere vsphere = null;
@@ -449,8 +475,8 @@ public class Clone extends VSphereBuildStep {
                     return FormValidation.error(Messages.validation_notFound("host"));
                 }
 
-                if (candidateHosts != null && !candidateHosts.isEmpty()) {
-                    for (String candidateHost : VSphereHostSelection.parseAllowList(candidateHosts)) {
+                if (hostSelectionCandidatesAsString != null && !hostSelectionCandidatesAsString.isEmpty()) {
+                    for (String candidateHost : VSphereHostSelection.parseAllowList(hostSelectionCandidatesAsString)) {
                         if (!vsphere.hostExists(candidateHost)) {
                             return FormValidation.error("Candidate host \"" + candidateHost + "\" was not found.");
                         }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jenkins.tasks.SimpleBuildStep;
+import org.jenkinsci.plugins.vSphereCloud;
 import org.jenkinsci.plugins.vsphere.VSphereBuildStep;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;
@@ -166,14 +167,20 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
         this.hostSelectionCandidates = hostSelectionCandidates == null ? null : new LinkedHashSet<>(hostSelectionCandidates);
     }
 
-    /** For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain string. */
+    /**
+     * For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain
+     * string. Blank means "inherit the cloud's default candidate list" (see {@link
+     * org.jenkinsci.plugins.vSphereCloud#getHostSelectionCandidates()}); a single comma
+     * explicitly overrides to "no restriction at this call site" - see {@link
+     * VSphereHostSelection#toAllowListString}.
+     */
     public String getHostSelectionCandidatesAsString() {
-        return VSphereHostSelection.toCsv(hostSelectionCandidates);
+        return VSphereHostSelection.toAllowListString(hostSelectionCandidates);
     }
 
     @DataBoundSetter
     public void setHostSelectionCandidatesAsString(String hostSelectionCandidatesCsv) {
-        this.hostSelectionCandidates = VSphereHostSelection.parseAllowList(hostSelectionCandidatesCsv);
+        this.hostSelectionCandidates = VSphereHostSelection.parseAllowListOrNull(hostSelectionCandidatesCsv);
     }
 
     @Override
@@ -267,7 +274,13 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             resourcePoolName = env.expand(resourcePool);
         }
 
-        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, expandedHost, hostSelectionMode, expandedHostSelectionCandidates, jLogger);
+        final vSphereCloud sourceCloud = getSourceCloud();
+        final String cloudDefaultHostSelectionMode = sourceCloud != null ? sourceCloud.getHostSelectionMode() : null;
+        final Set<String> cloudDefaultHostSelectionCandidates = sourceCloud != null ? sourceCloud.getHostSelectionCandidates() : null;
+        final String resolvedHostSelectionMode = VSphereHostSelection.resolveMode(cloudDefaultHostSelectionMode, hostSelectionMode);
+        final Set<String> resolvedHostSelectionCandidates = VSphereHostSelection.resolveCandidates(cloudDefaultHostSelectionCandidates, expandedHostSelectionCandidates);
+
+        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, expandedHost, resolvedHostSelectionMode, resolvedHostSelectionCandidates, jLogger);
         VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
         if (!powerOn) {
             return true; // don't try to obtain IP if VM isn't being turned on.
@@ -339,7 +352,8 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 
         public ListBoxModel doFillHostSelectionModeItems() {
             ListBoxModel items = new ListBoxModel();
-            items.add("(none - vCenter's own default placement)", "");
+            items.add("(none - inherit the cloud's default)", "");
+            items.add("Explicitly none (override the cloud's default)", VSphereHostSelection.HOST_SELECTION_MODE_NONE);
             items.add("Least loaded host (CPU/memory, no DRS license required)", "LEAST_LOADED");
             items.add("DRS recommendation (requires DRS enabled + licensed on the cluster)", "DRS_RECOMMENDED");
             return items;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -65,8 +67,8 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
     private String host;
     /** Optional; one of "", "LEAST_LOADED", "DRS_RECOMMENDED". Ignored when {@code host} is set. */
     private String hostSelectionMode;
-    /** Optional comma-separated allow-list restricting {@code hostSelectionMode}'s candidates. */
-    private String candidateHosts;
+    /** Optional allow-list restricting {@code hostSelectionMode}'s candidates. */
+    private Set<String> hostSelectionCandidates;
 
     @DataBoundConstructor
     public Deploy(String template, String clone, boolean linkedClone,
@@ -145,13 +147,33 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
         this.hostSelectionMode = hostSelectionMode;
     }
 
-    public String getCandidateHosts() {
-        return candidateHosts;
+    /** Canonical form, for pipeline/API/JCasC consumers. */
+    public Set<String> getHostSelectionCandidates() {
+        return hostSelectionCandidates;
+    }
+
+    /**
+     * Takes a flat list of individual host names - the natural shape for a pipeline or
+     * JCasC YAML caller that already has one. See {@link #setHostSelectionCandidatesAsString}
+     * for the comma-separated-string equivalent (used by the classic UI textbox). Both
+     * are kept as separate, concretely-typed properties rather than one that accepts
+     * either shape: Jenkins' JCasC introspection resolves exactly one configurator per
+     * property type, so a single {@code Object}-typed (or overloaded) setter is not
+     * reliably usable from YAML, even though pipeline's looser binding tolerates it.
+     */
+    @DataBoundSetter
+    public void setHostSelectionCandidates(Collection<String> hostSelectionCandidates) {
+        this.hostSelectionCandidates = hostSelectionCandidates == null ? null : new LinkedHashSet<>(hostSelectionCandidates);
+    }
+
+    /** For the classic config UI textbox, and pipeline/JCasC callers that prefer a plain string. */
+    public String getHostSelectionCandidatesAsString() {
+        return VSphereHostSelection.toCsv(hostSelectionCandidates);
     }
 
     @DataBoundSetter
-    public void setCandidateHosts(String candidateHosts) {
-        this.candidateHosts = candidateHosts;
+    public void setHostSelectionCandidatesAsString(String hostSelectionCandidatesCsv) {
+        this.hostSelectionCandidates = VSphereHostSelection.parseAllowList(hostSelectionCandidatesCsv);
     }
 
     @Override
@@ -209,7 +231,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
                 String expandedFolder = folder;
                 String expandedCustomizationSpec = customizationSpec;
         String expandedHost = host;
-        String expandedCandidateHosts = candidateHosts;
+        Set<String> expandedHostSelectionCandidates = hostSelectionCandidates;
         EnvVars env;
         try {
             env = run.getEnvironment(listener);
@@ -228,8 +250,11 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             if (host != null) {
                 expandedHost = env.expand(host);
             }
-            if (candidateHosts != null) {
-                expandedCandidateHosts = env.expand(candidateHosts);
+            if (hostSelectionCandidates != null) {
+                expandedHostSelectionCandidates = new LinkedHashSet<>();
+                for (String candidateHost : hostSelectionCandidates) {
+                    expandedHostSelectionCandidates.add(env.expand(candidateHost));
+                }
             }
         }
 
@@ -242,7 +267,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             resourcePoolName = env.expand(resourcePool);
         }
 
-        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, expandedHost, hostSelectionMode, expandedCandidateHosts, jLogger);
+        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, expandedHost, hostSelectionMode, expandedHostSelectionCandidates, jLogger);
         VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
         if (!powerOn) {
             return true; // don't try to obtain IP if VM isn't being turned on.
@@ -325,7 +350,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
                 @QueryParameter String serverName,
                 @QueryParameter String template, @QueryParameter String clone,
                 @QueryParameter String resourcePool, @QueryParameter String cluster,
-                @QueryParameter String host, @QueryParameter String candidateHosts) {
+                @QueryParameter String host, @QueryParameter String hostSelectionCandidatesAsString) {
             throwUnlessUserHasPermissionToConfigureJob(context);
             VSphere vsphere = null;
             try {
@@ -354,8 +379,8 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
                     return FormValidation.error(Messages.validation_notFound("host"));
                 }
 
-                if (candidateHosts != null && !candidateHosts.isEmpty()) {
-                    for (String candidateHost : VSphereHostSelection.parseAllowList(candidateHosts)) {
+                if (hostSelectionCandidatesAsString != null && !hostSelectionCandidatesAsString.isEmpty()) {
+                    for (String candidateHost : VSphereHostSelection.parseAllowList(hostSelectionCandidatesAsString)) {
                         if (!vsphere.hostExists(candidateHost)) {
                             return FormValidation.error("Candidate host \"" + candidateHost + "\" was not found.");
                         }

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/Deploy.java
@@ -20,6 +20,7 @@ import hudson.*;
 import hudson.model.*;
 import hudson.tasks.BuildStepMonitor;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -33,9 +34,11 @@ import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.vsphere.VSphereBuildStep;
 import org.jenkinsci.plugins.vsphere.tools.VSphere;
 import org.jenkinsci.plugins.vsphere.tools.VSphereException;
+import org.jenkinsci.plugins.vsphere.tools.VSphereHostSelection;
 import org.jenkinsci.plugins.vsphere.tools.VSphereLogger;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -57,6 +60,13 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
     /** null means use default, zero or negative means don't even try at all. */
     private final Integer timeoutInSeconds;
     private String IP;
+
+    /** Optional; unset means unchanged legacy behaviour (vCenter's own default placement). */
+    private String host;
+    /** Optional; one of "", "LEAST_LOADED", "DRS_RECOMMENDED". Ignored when {@code host} is set. */
+    private String hostSelectionMode;
+    /** Optional comma-separated allow-list restricting {@code hostSelectionMode}'s candidates. */
+    private String candidateHosts;
 
     @DataBoundConstructor
     public Deploy(String template, String clone, boolean linkedClone,
@@ -117,6 +127,33 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
         return timeoutInSeconds.intValue();
     }
 
+    public String getHost() {
+        return host;
+    }
+
+    @DataBoundSetter
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getHostSelectionMode() {
+        return hostSelectionMode;
+    }
+
+    @DataBoundSetter
+    public void setHostSelectionMode(String hostSelectionMode) {
+        this.hostSelectionMode = hostSelectionMode;
+    }
+
+    public String getCandidateHosts() {
+        return candidateHosts;
+    }
+
+    @DataBoundSetter
+    public void setCandidateHosts(String candidateHosts) {
+        this.candidateHosts = candidateHosts;
+    }
+
     @Override
     public String getIP() {
         return IP;
@@ -171,6 +208,8 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
         String expandedDatastore = datastore;
                 String expandedFolder = folder;
                 String expandedCustomizationSpec = customizationSpec;
+        String expandedHost = host;
+        String expandedCandidateHosts = candidateHosts;
         EnvVars env;
         try {
             env = run.getEnvironment(listener);
@@ -186,6 +225,12 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             expandedDatastore = env.expand(datastore);
                         expandedFolder = env.expand(folder);
                         expandedCustomizationSpec = env.expand(customizationSpec);
+            if (host != null) {
+                expandedHost = env.expand(host);
+            }
+            if (candidateHosts != null) {
+                expandedCandidateHosts = env.expand(candidateHosts);
+            }
         }
 
         String resourcePoolName;
@@ -197,7 +242,7 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             resourcePoolName = env.expand(resourcePool);
         }
 
-        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, jLogger);
+        vsphere.deployVm(expandedClone, expandedTemplate, linkedClone, resourcePoolName, expandedCluster, expandedDatastore, expandedFolder, powerOn, expandedCustomizationSpec, expandedHost, hostSelectionMode, expandedCandidateHosts, jLogger);
         VSphereLogger.vsLogger(jLogger, "\""+expandedClone+"\" successfully deployed!");
         if (!powerOn) {
             return true; // don't try to obtain IP if VM isn't being turned on.
@@ -267,11 +312,20 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
             return FormValidation.validateNonNegativeInteger(value);
         }
 
+        public ListBoxModel doFillHostSelectionModeItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("(none - vCenter's own default placement)", "");
+            items.add("Least loaded host (CPU/memory, no DRS license required)", "LEAST_LOADED");
+            items.add("DRS recommendation (requires DRS enabled + licensed on the cluster)", "DRS_RECOMMENDED");
+            return items;
+        }
+
         @RequirePOST
         public FormValidation doTestData(@AncestorInPath Item context,
                 @QueryParameter String serverName,
                 @QueryParameter String template, @QueryParameter String clone,
-                @QueryParameter String resourcePool, @QueryParameter String cluster) {
+                @QueryParameter String resourcePool, @QueryParameter String cluster,
+                @QueryParameter String host, @QueryParameter String candidateHosts) {
             throwUnlessUserHasPermissionToConfigureJob(context);
             VSphere vsphere = null;
             try {
@@ -295,6 +349,18 @@ public class Deploy extends VSphereBuildStep implements SimpleBuildStep {
 
                 if(!vm.getConfig().template)
                     return FormValidation.error(Messages.validation_notActually("template"));
+
+                if (host != null && !host.isEmpty() && !vsphere.hostExists(host)) {
+                    return FormValidation.error(Messages.validation_notFound("host"));
+                }
+
+                if (candidateHosts != null && !candidateHosts.isEmpty()) {
+                    for (String candidateHost : VSphereHostSelection.parseAllowList(candidateHosts)) {
+                        if (!vsphere.hostExists(candidateHost)) {
+                            return FormValidation.error("Candidate host \"" + candidateHost + "\" was not found.");
+                        }
+                    }
+                }
 
                 return FormValidation.ok(Messages.validation_success());
             } catch (Exception e) {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -217,15 +217,15 @@ public class VSphere {
     /**
      * Deploys a new VM from an existing template, with control over which ESXi host the clone
      * is placed on. See {@link #cloneOrDeployVm} for the meaning of {@code host}, {@code
-     * hostSelectionMode} and {@code candidateHosts}.
+     * hostSelectionMode} and {@code hostSelectionCandidates}.
      *
      * @throws VSphereException If an error occurred.
      */
-    public void deployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, String host, String hostSelectionMode, String candidateHosts, PrintStream jLogger) throws VSphereException {
+    public void deployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, String host, String hostSelectionMode, Set<String> hostSelectionCandidates, PrintStream jLogger) throws VSphereException {
         final boolean useCurrentSnapshotIsFALSE = false;
         final String namedSnapshotIsNULL = null;
         final Map<String, String> extraConfigParameters = null;
-        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsFALSE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, host, hostSelectionMode, candidateHosts, jLogger);
+        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsFALSE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, host, hostSelectionMode, hostSelectionCandidates, jLogger);
     }
 
     /**
@@ -250,15 +250,15 @@ public class VSphere {
     /**
      * Clones a new VM from an existing (named) VM, with control over which ESXi host the clone
      * is placed on. See {@link #cloneOrDeployVm} for the meaning of {@code host}, {@code
-     * hostSelectionMode} and {@code candidateHosts}.
+     * hostSelectionMode} and {@code hostSelectionCandidates}.
      *
      * @throws VSphereException If an error occurred.
      */
-    public void cloneVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, String host, String hostSelectionMode, String candidateHosts, PrintStream jLogger) throws VSphereException {
+    public void cloneVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, String host, String hostSelectionMode, Set<String> hostSelectionCandidates, PrintStream jLogger) throws VSphereException {
         final boolean useCurrentSnapshotIsTRUE = true;
         final String namedSnapshotIsNULL = null;
         final Map<String, String> extraConfigParameters = null;
-        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsTRUE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, host, hostSelectionMode, candidateHosts, jLogger);
+        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsTRUE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, host, hostSelectionMode, hostSelectionCandidates, jLogger);
     }
 
     /**
@@ -329,16 +329,17 @@ public class VSphere {
      *            recommendation restricted to the candidate hosts (requires DRS to be enabled
      *            and licensed on the cluster; falls back to {@code "LEAST_LOADED"} behaviour
      *            if DRS is unavailable or returns no recommendation).
-     * @param candidateHosts
-     *            (Optional) Comma-separated list of host names that {@code hostSelectionMode}
-     *            is allowed to consider; other hosts in the cluster are ignored even if they
-     *            would otherwise be a better pick. Use this when the vCenter account used for
-     *            cloning does not have provisioning permission on every host in the cluster.
-     *            Blank/null means every (usable) host in {@code cluster} is a candidate.
+     * @param hostSelectionCandidates
+     *            (Optional) Set of host names that {@code hostSelectionMode} is allowed to
+     *            consider; other hosts in the cluster are ignored even if they would otherwise
+     *            be a better pick. Use this when the vCenter account used for cloning does not
+     *            have provisioning permission on every host in the cluster. Empty/null means
+     *            every (usable) host in {@code cluster} is a candidate. Callers holding a
+     *            comma-separated string can use {@link VSphereHostSelection#parseAllowList}.
      * @throws VSphereException
      *             if anything goes wrong.
      */
-    public void cloneOrDeployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean useCurrentSnapshot, final String namedSnapshot, boolean powerOn, Map<String, String> extraConfigParameters, String customizationSpec, String host, String hostSelectionMode, String candidateHosts, PrintStream jLogger) throws VSphereException {
+    public void cloneOrDeployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean useCurrentSnapshot, final String namedSnapshot, boolean powerOn, Map<String, String> extraConfigParameters, String customizationSpec, String host, String hostSelectionMode, Set<String> hostSelectionCandidates, PrintStream jLogger) throws VSphereException {
         if (namedSnapshot == null && extraConfigParameters == null) {
             // NOTE: This "if" clause may be superfluous - just that previously
             // this message was only logged by cloneVm() or deployVm()... so for
@@ -412,7 +413,7 @@ public class VSphere {
                 folder = getFolder(folderName);
             }
 
-            final HostSystem selectedHost = selectHost(jLogger, getClusterByName(cluster), sourceVm, cloneName, cloneSpec, rel, host, hostSelectionMode, candidateHosts);
+            final HostSystem selectedHost = selectHost(jLogger, getClusterByName(cluster), sourceVm, cloneName, cloneSpec, rel, host, hostSelectionMode, hostSelectionCandidates);
             if (selectedHost != null) {
                 rel.setHost(selectedHost.getMOR());
                 logMessage(jLogger, "Clone of " + sourceType + " \"" + sourceName + "\" will be placed on host \"" + selectedHost.getName() + "\".");
@@ -483,7 +484,7 @@ public class VSphere {
     /**
      * Checks whether a host with this name exists anywhere in the vCenter inventory. Used by
      * build-step/config live-validation ("Check Data"/"Check Template" buttons) for the
-     * {@code host}/{@code targetHost} and {@code candidateHosts} fields.
+     * {@code host}/{@code targetHost} and {@code hostSelectionCandidates} fields.
      *
      * @throws VSphereException If an error occurred while querying vCenter.
      */
@@ -509,12 +510,34 @@ public class VSphere {
     }
 
     /**
+     * If the vCenter inventory contains exactly one cluster, returns it - so that host
+     * selection can still work when the caller didn't (or couldn't be bothered to)
+     * specify a {@code cluster}. Returns null if there are zero or multiple clusters,
+     * since then there's no way to pick one automatically.
+     */
+    private ClusterComputeResource getSingleClusterIfUnambiguous(PrintStream jLogger) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
+        final ManagedEntity[] allClusters = new InventoryNavigator(
+                getServiceInstance().getRootFolder()).searchManagedEntities("ClusterComputeResource");
+        if (allClusters == null || allClusters.length == 0) {
+            logMessage(jLogger, "No cluster was specified, and no cluster exists in this vCenter's inventory; cannot auto-select a host.");
+            return null;
+        }
+        if (allClusters.length > 1) {
+            logMessage(jLogger, "No cluster was specified, and " + allClusters.length + " clusters exist in this vCenter's inventory; specify \"cluster\" explicitly to enable host selection.");
+            return null;
+        }
+        final ClusterComputeResource onlyCluster = (ClusterComputeResource) allClusters[0];
+        logMessage(jLogger, "No cluster was specified; auto-detected the only cluster in this vCenter's inventory: \"" + onlyCluster.getName() + "\".");
+        return onlyCluster;
+    }
+
+    /**
      * Decides which ESXi host (if any) a clone should be placed on. Returns null to mean
      * "no restriction, let vCenter/DRS decide with its own default logic" (today's behaviour).
      */
     private HostSystem selectHost(PrintStream jLogger, ClusterComputeResource clusterResource, VirtualMachine sourceVm,
             String cloneName, VirtualMachineCloneSpec cloneSpec, VirtualMachineRelocateSpec rel,
-            String host, String hostSelectionMode, String candidateHosts)
+            String host, String hostSelectionMode, Set<String> hostSelectionCandidates)
             throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException, VSphereException {
         if (host != null && !host.isEmpty()) {
             HostSystem explicitHost = getHostByName(host, clusterResource);
@@ -529,7 +552,10 @@ public class VSphere {
         }
 
         if (clusterResource == null) {
-            logMessage(jLogger, "Host selection mode \"" + hostSelectionMode + "\" requires a valid cluster to be specified; letting vSphere decide placement.");
+            clusterResource = getSingleClusterIfUnambiguous(jLogger);
+        }
+        if (clusterResource == null) {
+            logMessage(jLogger, "Host selection mode \"" + hostSelectionMode + "\" requires a valid cluster to be specified (or exactly one cluster to exist in the vCenter inventory); letting vSphere decide placement.");
             return null;
         }
 
@@ -543,8 +569,7 @@ public class VSphere {
             }
         }
 
-        final Set<String> allowList = VSphereHostSelection.parseAllowList(candidateHosts);
-        final List<HostCandidate> filtered = VSphereHostSelection.filterCandidates(candidates, allowList);
+        final List<HostCandidate> filtered = VSphereHostSelection.filterCandidates(candidates, hostSelectionCandidates);
         if (filtered.isEmpty()) {
             logMessage(jLogger, "No usable candidate hosts found in cluster \"" + clusterResource.getName() + "\" for host selection mode \"" + hostSelectionMode + "\"; letting vSphere decide placement.");
             return null;

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -21,6 +21,7 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
@@ -30,11 +31,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.vsphere.VSphereConnectionConfig;
 
+import com.vmware.vim25.ClusterRecommendation;
 import com.vmware.vim25.CustomizationSpecItem;
 import com.vmware.vim25.GuestInfo;
+import com.vmware.vim25.HostHardwareSummary;
+import com.vmware.vim25.HostListSummary;
+import com.vmware.vim25.HostListSummaryQuickStats;
+import com.vmware.vim25.HostRuntimeInfo;
+import com.vmware.vim25.HostSystemConnectionState;
 import com.vmware.vim25.InvalidProperty;
 import com.vmware.vim25.ManagedObjectReference;
 import com.vmware.vim25.OptionValue;
+import com.vmware.vim25.PlacementResult;
+import com.vmware.vim25.PlacementSpec;
 import com.vmware.vim25.RuntimeFault;
 import com.vmware.vim25.TaskInfo;
 import com.vmware.vim25.TaskInfoState;
@@ -51,6 +60,7 @@ import com.vmware.vim25.mo.ClusterComputeResource;
 import com.vmware.vim25.mo.CustomizationSpecManager;
 import com.vmware.vim25.mo.Datastore;
 import com.vmware.vim25.mo.Folder;
+import com.vmware.vim25.mo.HostSystem;
 import com.vmware.vim25.mo.InventoryNavigator;
 import com.vmware.vim25.mo.ManagedEntity;
 import com.vmware.vim25.mo.ResourcePool;
@@ -63,6 +73,7 @@ import com.vmware.vim25.mo.Datacenter;
 import com.vmware.vim25.mo.Network;
 import com.vmware.vim25.mo.DistributedVirtualPortgroup;
 import com.vmware.vim25.mo.DistributedVirtualSwitch;
+import org.jenkinsci.plugins.vsphere.tools.VSphereHostSelection.HostCandidate;
 
 public class VSphere {
     private final URL url;
@@ -200,10 +211,21 @@ public class VSphere {
      * @throws VSphereException If an error occurred.
      */
     public void deployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, PrintStream jLogger) throws VSphereException {
+        deployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, powerOn, customizationSpec, null, null, null, jLogger);
+    }
+
+    /**
+     * Deploys a new VM from an existing template, with control over which ESXi host the clone
+     * is placed on. See {@link #cloneOrDeployVm} for the meaning of {@code host}, {@code
+     * hostSelectionMode} and {@code candidateHosts}.
+     *
+     * @throws VSphereException If an error occurred.
+     */
+    public void deployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, String host, String hostSelectionMode, String candidateHosts, PrintStream jLogger) throws VSphereException {
         final boolean useCurrentSnapshotIsFALSE = false;
         final String namedSnapshotIsNULL = null;
         final Map<String, String> extraConfigParameters = null;
-        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsFALSE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, jLogger);
+        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsFALSE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, host, hostSelectionMode, candidateHosts, jLogger);
     }
 
     /**
@@ -222,10 +244,21 @@ public class VSphere {
      * @throws VSphereException If an error occurred.
      */
     public void cloneVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, PrintStream jLogger) throws VSphereException {
+        cloneVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, powerOn, customizationSpec, null, null, null, jLogger);
+    }
+
+    /**
+     * Clones a new VM from an existing (named) VM, with control over which ESXi host the clone
+     * is placed on. See {@link #cloneOrDeployVm} for the meaning of {@code host}, {@code
+     * hostSelectionMode} and {@code candidateHosts}.
+     *
+     * @throws VSphereException If an error occurred.
+     */
+    public void cloneVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean powerOn, String customizationSpec, String host, String hostSelectionMode, String candidateHosts, PrintStream jLogger) throws VSphereException {
         final boolean useCurrentSnapshotIsTRUE = true;
         final String namedSnapshotIsNULL = null;
         final Map<String, String> extraConfigParameters = null;
-        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsTRUE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, jLogger);
+        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshotIsTRUE, namedSnapshotIsNULL, powerOn, extraConfigParameters, customizationSpec, host, hostSelectionMode, candidateHosts, jLogger);
     }
 
     /**
@@ -274,6 +307,38 @@ public class VSphere {
      *             if anything goes wrong.
      */
     public void cloneOrDeployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean useCurrentSnapshot, final String namedSnapshot, boolean powerOn, Map<String, String> extraConfigParameters, String customizationSpec, PrintStream jLogger) throws VSphereException {
+        cloneOrDeployVm(cloneName, sourceName, linkedClone, resourcePoolName, cluster, datastoreName, folderName, useCurrentSnapshot, namedSnapshot, powerOn, extraConfigParameters, customizationSpec, null, null, null, jLogger);
+    }
+
+    /**
+     * Creates a new VM by cloning an existing VM or Template, with control over which ESXi host
+     * the clone is placed on. Without this, clones are placed wherever vCenter's own default
+     * logic decides (in practice, often the same host the source VM/template is registered on),
+     * which can cause load imbalance across a cluster.
+     *
+     * @param host
+     *            (Optional) The name of a specific ESXi host to place the clone on. When set,
+     *            this always wins and {@code hostSelectionMode} is ignored. Works regardless of
+     *            vSphere edition/license and regardless of DRS configuration.
+     * @param hostSelectionMode
+     *            (Optional) When {@code host} is not set, how to automatically pick a host:
+     *            {@code null}/empty for unchanged legacy behaviour (let vCenter decide),
+     *            {@code "LEAST_LOADED"} to have this plugin rank candidate hosts in {@code
+     *            cluster} by current CPU/memory usage and pick the least loaded one, or
+     *            {@code "DRS_RECOMMENDED"} to ask vCenter's own DRS engine for a placement
+     *            recommendation restricted to the candidate hosts (requires DRS to be enabled
+     *            and licensed on the cluster; falls back to {@code "LEAST_LOADED"} behaviour
+     *            if DRS is unavailable or returns no recommendation).
+     * @param candidateHosts
+     *            (Optional) Comma-separated list of host names that {@code hostSelectionMode}
+     *            is allowed to consider; other hosts in the cluster are ignored even if they
+     *            would otherwise be a better pick. Use this when the vCenter account used for
+     *            cloning does not have provisioning permission on every host in the cluster.
+     *            Blank/null means every (usable) host in {@code cluster} is a candidate.
+     * @throws VSphereException
+     *             if anything goes wrong.
+     */
+    public void cloneOrDeployVm(String cloneName, String sourceName, boolean linkedClone, String resourcePoolName, String cluster, String datastoreName, String folderName, boolean useCurrentSnapshot, final String namedSnapshot, boolean powerOn, Map<String, String> extraConfigParameters, String customizationSpec, String host, String hostSelectionMode, String candidateHosts, PrintStream jLogger) throws VSphereException {
         if (namedSnapshot == null && extraConfigParameters == null) {
             // NOTE: This "if" clause may be superfluous - just that previously
             // this message was only logged by cloneVm() or deployVm()... so for
@@ -347,6 +412,12 @@ public class VSphere {
                 folder = getFolder(folderName);
             }
 
+            final HostSystem selectedHost = selectHost(jLogger, getClusterByName(cluster), sourceVm, cloneName, cloneSpec, rel, host, hostSelectionMode, candidateHosts);
+            if (selectedHost != null) {
+                rel.setHost(selectedHost.getMOR());
+                logMessage(jLogger, "Clone of " + sourceType + " \"" + sourceName + "\" will be placed on host \"" + selectedHost.getName() + "\".");
+            }
+
             final Task task = sourceVm.cloneVM_Task(folder,
                     cloneName, cloneSpec);
             logMessage(jLogger, "Started cloning of " + sourceType + " \"" + sourceName + "\". Please wait ...");
@@ -407,6 +478,179 @@ public class VSphere {
             rel.setDatastore(datastore.getMOR());
         }
        return rel;
+    }
+
+    /**
+     * Checks whether a host with this name exists anywhere in the vCenter inventory. Used by
+     * build-step/config live-validation ("Check Data"/"Check Template" buttons) for the
+     * {@code host}/{@code targetHost} and {@code candidateHosts} fields.
+     *
+     * @throws VSphereException If an error occurred while querying vCenter.
+     */
+    public boolean hostExists(final String hostName) throws VSphereException {
+        try {
+            return getHostByName(hostName, null) != null;
+        } catch (Exception e) {
+            throw new VSphereException(e);
+        }
+    }
+
+    /**
+     * @param hostName - Name of host to find
+     * @param rootEntity - managed entity to search, or null to search the whole inventory
+     * @return - HostSystem object, or null if not found
+     */
+    private HostSystem getHostByName(final String hostName, ManagedEntity rootEntity) throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException {
+        if (rootEntity == null) rootEntity = getServiceInstance().getRootFolder();
+
+        return (HostSystem) new InventoryNavigator(
+                rootEntity).searchManagedEntity(
+                        "HostSystem", hostName);
+    }
+
+    /**
+     * Decides which ESXi host (if any) a clone should be placed on. Returns null to mean
+     * "no restriction, let vCenter/DRS decide with its own default logic" (today's behaviour).
+     */
+    private HostSystem selectHost(PrintStream jLogger, ClusterComputeResource clusterResource, VirtualMachine sourceVm,
+            String cloneName, VirtualMachineCloneSpec cloneSpec, VirtualMachineRelocateSpec rel,
+            String host, String hostSelectionMode, String candidateHosts)
+            throws InvalidProperty, RuntimeFault, RemoteException, MalformedURLException, VSphereException {
+        if (host != null && !host.isEmpty()) {
+            HostSystem explicitHost = getHostByName(host, clusterResource);
+            if (explicitHost == null) {
+                throw new VSphereNotFoundException("Host", host);
+            }
+            return explicitHost;
+        }
+
+        if (hostSelectionMode == null || hostSelectionMode.isEmpty()) {
+            return null;
+        }
+
+        if (clusterResource == null) {
+            logMessage(jLogger, "Host selection mode \"" + hostSelectionMode + "\" requires a valid cluster to be specified; letting vSphere decide placement.");
+            return null;
+        }
+
+        final HostSystem[] members = clusterResource.getHost();
+        final List<HostSystem> hostSystems = new ArrayList<>();
+        final List<HostCandidate> candidates = new ArrayList<>();
+        if (members != null) {
+            for (HostSystem hostSystem : members) {
+                hostSystems.add(hostSystem);
+                candidates.add(toHostCandidate(hostSystem));
+            }
+        }
+
+        final Set<String> allowList = VSphereHostSelection.parseAllowList(candidateHosts);
+        final List<HostCandidate> filtered = VSphereHostSelection.filterCandidates(candidates, allowList);
+        if (filtered.isEmpty()) {
+            logMessage(jLogger, "No usable candidate hosts found in cluster \"" + clusterResource.getName() + "\" for host selection mode \"" + hostSelectionMode + "\"; letting vSphere decide placement.");
+            return null;
+        }
+
+        if ("DRS_RECOMMENDED".equals(hostSelectionMode)) {
+            HostSystem recommended = recommendHostViaDrs(jLogger, clusterResource, sourceVm, cloneName, cloneSpec, rel, hostSystems, filtered);
+            if (recommended != null) {
+                return recommended;
+            }
+            logMessage(jLogger, "DRS placement recommendation was unavailable (DRS may be disabled or unlicensed on this cluster); falling back to least-loaded host selection.");
+        }
+
+        final HostCandidate winner = VSphereHostSelection.pickLeastLoaded(filtered);
+        if (winner == null) {
+            logMessage(jLogger, "Unable to determine current load for any candidate host; letting vSphere decide placement.");
+            return null;
+        }
+        return findHostSystemByName(hostSystems, winner.getName());
+    }
+
+    /**
+     * Asks vCenter's own DRS engine for a placement recommendation, restricted to the given
+     * (already permission/availability-filtered) candidate hosts. Returns null - never throws -
+     * if DRS is unavailable, unlicensed, disabled on the cluster, or gives no recommendation, so
+     * callers can fall back to a simpler heuristic.
+     */
+    private HostSystem recommendHostViaDrs(PrintStream jLogger, ClusterComputeResource clusterResource, VirtualMachine sourceVm,
+            String cloneName, VirtualMachineCloneSpec cloneSpec, VirtualMachineRelocateSpec rel,
+            List<HostSystem> hostSystems, List<HostCandidate> filtered) {
+        try {
+            final ManagedObjectReference[] candidateMors = new ManagedObjectReference[filtered.size()];
+            for (int i = 0; i < filtered.size(); i++) {
+                HostSystem hostSystem = findHostSystemByName(hostSystems, filtered.get(i).getName());
+                if (hostSystem == null) {
+                    return null;
+                }
+                candidateMors[i] = hostSystem.getMOR();
+            }
+
+            final PlacementSpec placementSpec = new PlacementSpec();
+            placementSpec.setPlacementType("clone");
+            placementSpec.setVm(sourceVm.getMOR());
+            placementSpec.setCloneName(cloneName);
+            placementSpec.setCloneSpec(cloneSpec);
+            placementSpec.setRelocateSpec(rel);
+            placementSpec.setHosts(candidateMors);
+
+            final PlacementResult result = clusterResource.placeVm(placementSpec);
+            if (result == null || result.getRecommendations() == null || result.getRecommendations().length == 0) {
+                return null;
+            }
+
+            ClusterRecommendation best = null;
+            for (ClusterRecommendation recommendation : result.getRecommendations()) {
+                if (best == null || recommendation.getRating() > best.getRating()) {
+                    best = recommendation;
+                }
+            }
+            if (best == null || best.getTarget() == null) {
+                return null;
+            }
+            for (HostSystem hostSystem : hostSystems) {
+                if (hostSystem.getMOR().equals(best.getTarget())) {
+                    return hostSystem;
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "DRS placement recommendation failed, will fall back to least-loaded host selection", e);
+            return null;
+        }
+    }
+
+    private HostCandidate toHostCandidate(HostSystem hostSystem) {
+        final HostListSummary summary = hostSystem.getSummary();
+        final HostRuntimeInfo runtime = hostSystem.getRuntime();
+        final boolean connected = runtime != null && runtime.getConnectionState() == HostSystemConnectionState.connected;
+        final boolean inMaintenanceMode = runtime != null && runtime.isInMaintenanceMode();
+
+        Integer cpuUsageMhz = null;
+        Integer memUsageMB = null;
+        int cpuCapacityMhz = 0;
+        long memCapacityMB = 0L;
+        if (summary != null) {
+            final HostListSummaryQuickStats quickStats = summary.getQuickStats();
+            if (quickStats != null) {
+                cpuUsageMhz = quickStats.getOverallCpuUsage();
+                memUsageMB = quickStats.getOverallMemoryUsage();
+            }
+            final HostHardwareSummary hardware = summary.getHardware();
+            if (hardware != null) {
+                cpuCapacityMhz = hardware.getCpuMhz() * hardware.getNumCpuCores();
+                memCapacityMB = hardware.getMemorySize() / (1024L * 1024L);
+            }
+        }
+        return new HostCandidate(hostSystem.getName(), connected, inMaintenanceMode, cpuUsageMhz, cpuCapacityMhz, memUsageMB, memCapacityMB);
+    }
+
+    private static HostSystem findHostSystemByName(List<HostSystem> hostSystems, String name) {
+        for (HostSystem hostSystem : hostSystems) {
+            if (hostSystem.getName().equals(name)) {
+                return hostSystem;
+            }
+        }
+        return null;
     }
 
     public void reconfigureVm(String name, VirtualMachineConfigSpec spec) throws VSphereException {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelection.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelection.java
@@ -1,0 +1,160 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Pure, yavijava-free logic for picking a "best" ESXi host out of a
+ * cluster's members, given per-host stats and an optional admin-supplied
+ * allow-list. Kept free of vSphere API types so it can be unit-tested
+ * without a live vCenter connection.
+ */
+public final class VSphereHostSelection {
+
+    private VSphereHostSelection() {
+    }
+
+    /**
+     * Describes one candidate host's name, availability and current load,
+     * as needed to decide whether/how favourably it can be used for a new
+     * clone.
+     */
+    public static final class HostCandidate {
+        private final String name;
+        private final boolean connected;
+        private final boolean inMaintenanceMode;
+        private final Integer cpuUsageMhz;
+        private final int cpuCapacityMhz;
+        private final Integer memUsageMB;
+        private final long memCapacityMB;
+
+        public HostCandidate(String name, boolean connected, boolean inMaintenanceMode,
+                Integer cpuUsageMhz, int cpuCapacityMhz, Integer memUsageMB, long memCapacityMB) {
+            this.name = name;
+            this.connected = connected;
+            this.inMaintenanceMode = inMaintenanceMode;
+            this.cpuUsageMhz = cpuUsageMhz;
+            this.cpuCapacityMhz = cpuCapacityMhz;
+            this.memUsageMB = memUsageMB;
+            this.memCapacityMB = memCapacityMB;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isConnected() {
+            return connected;
+        }
+
+        public boolean isInMaintenanceMode() {
+            return inMaintenanceMode;
+        }
+
+        public Integer getCpuUsageMhz() {
+            return cpuUsageMhz;
+        }
+
+        public int getCpuCapacityMhz() {
+            return cpuCapacityMhz;
+        }
+
+        public Integer getMemUsageMB() {
+            return memUsageMB;
+        }
+
+        public long getMemCapacityMB() {
+            return memCapacityMB;
+        }
+
+        /**
+         * Fraction of capacity currently in use, taking the higher (more
+         * constrained) of CPU and memory. Returns null if usage stats are
+         * missing (stale/unavailable), so the host can be excluded rather
+         * than mis-ranked.
+         */
+        public Double loadFraction() {
+            if (cpuUsageMhz == null || memUsageMB == null) {
+                return null;
+            }
+            double cpuFraction = cpuCapacityMhz > 0 ? (double) cpuUsageMhz / cpuCapacityMhz : 0d;
+            double memFraction = memCapacityMB > 0 ? (double) memUsageMB / memCapacityMB : 0d;
+            return Math.max(cpuFraction, memFraction);
+        }
+
+        /**
+         * True if the host is currently usable at all (connected and not in
+         * maintenance mode), regardless of load.
+         */
+        public boolean isUsable() {
+            return connected && !inMaintenanceMode;
+        }
+    }
+
+    /**
+     * Parses a comma-separated allow-list of host names, trimming whitespace
+     * and discarding empty entries. Returns an empty (not null) set when the
+     * input is null/blank, meaning "no restriction".
+     */
+    public static Set<String> parseAllowList(String candidateHostsCsv) {
+        Set<String> result = new LinkedHashSet<>();
+        if (candidateHostsCsv == null || candidateHostsCsv.trim().isEmpty()) {
+            return result;
+        }
+        for (String name : candidateHostsCsv.split(",")) {
+            String trimmed = name.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Filters candidates down to ones that are usable (connected, not in
+     * maintenance mode) and, if the allow-list is non-empty, whose name is
+     * in it. An empty/null allow-list means "consider every usable host".
+     */
+    public static List<HostCandidate> filterCandidates(List<HostCandidate> candidates, Set<String> allowList) {
+        List<HostCandidate> result = new ArrayList<>();
+        for (HostCandidate candidate : candidates) {
+            if (!candidate.isUsable()) {
+                continue;
+            }
+            if (!allowList.isEmpty() && !allowList.contains(candidate.getName())) {
+                continue;
+            }
+            result.add(candidate);
+        }
+        return result;
+    }
+
+    /**
+     * Picks the candidate with the lowest load fraction, excluding any
+     * candidate whose stats are unavailable. Returns null if no candidate
+     * has usable stats.
+     */
+    public static HostCandidate pickLeastLoaded(List<HostCandidate> candidates) {
+        HostCandidate best = null;
+        double bestLoad = Double.MAX_VALUE;
+        for (HostCandidate candidate : candidates) {
+            Double load = candidate.loadFraction();
+            if (load == null) {
+                continue;
+            }
+            if (best == null || load < bestLoad) {
+                best = candidate;
+                bestLoad = load;
+            }
+        }
+        return best;
+    }
+
+    /** Convenience: same as calling {@link Arrays#asList} for tests. */
+    public static List<HostCandidate> listOf(HostCandidate... candidates) {
+        return Arrays.asList(candidates);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelection.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelection.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.vsphere.tools;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -99,18 +100,30 @@ public final class VSphereHostSelection {
      * and discarding empty entries. Returns an empty (not null) set when the
      * input is null/blank, meaning "no restriction".
      */
-    public static Set<String> parseAllowList(String candidateHostsCsv) {
+    public static Set<String> parseAllowList(String hostSelectionCandidatesCsv) {
         Set<String> result = new LinkedHashSet<>();
-        if (candidateHostsCsv == null || candidateHostsCsv.trim().isEmpty()) {
+        if (hostSelectionCandidatesCsv == null || hostSelectionCandidatesCsv.trim().isEmpty()) {
             return result;
         }
-        for (String name : candidateHostsCsv.split(",")) {
+        for (String name : hostSelectionCandidatesCsv.split(",")) {
             String trimmed = name.trim();
             if (!trimmed.isEmpty()) {
                 result.add(trimmed);
             }
         }
         return result;
+    }
+
+    /**
+     * Joins a collection of host names back into the comma-separated form used by the
+     * classic config UI textbox. Returns "" (not null) for a null/empty input, so this
+     * is safe to use directly as a form field's current value.
+     */
+    public static String toCsv(Collection<String> hosts) {
+        if (hosts == null || hosts.isEmpty()) {
+            return "";
+        }
+        return String.join(", ", hosts);
     }
 
     /**
@@ -124,7 +137,7 @@ public final class VSphereHostSelection {
             if (!candidate.isUsable()) {
                 continue;
             }
-            if (!allowList.isEmpty() && !allowList.contains(candidate.getName())) {
+            if (allowList != null && !allowList.isEmpty() && !allowList.contains(candidate.getName())) {
                 continue;
             }
             result.add(candidate);

--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelection.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelection.java
@@ -15,6 +15,13 @@ import java.util.Set;
  */
 public final class VSphereHostSelection {
 
+    /**
+     * Explicit "no host selection" override for a template/build-step's {@code
+     * hostSelectionMode}, distinct from leaving it blank (which means "inherit the
+     * cloud-level default" - see {@link #resolveMode}).
+     */
+    public static final String HOST_SELECTION_MODE_NONE = "NONE";
+
     private VSphereHostSelection() {
     }
 
@@ -124,6 +131,64 @@ public final class VSphereHostSelection {
             return "";
         }
         return String.join(", ", hosts);
+    }
+
+    /**
+     * Like {@link #parseAllowList}, but preserves the "not set at all" case as null
+     * instead of collapsing it to an empty set - needed so a blank {@code
+     * hostSelectionCandidatesAsString} can mean "inherit the cloud-level default" (see
+     * {@link #resolveCandidates}) while a deliberately non-blank-but-hostless value
+     * (e.g. a lone comma) can still mean "explicitly override to no restriction".
+     * Blank/whitespace-only input (including a single space) is treated as "not set";
+     * anything else is parsed normally, which may still yield an empty (non-null) set.
+     */
+    public static Set<String> parseAllowListOrNull(String hostSelectionCandidatesCsv) {
+        if (hostSelectionCandidatesCsv == null || hostSelectionCandidatesCsv.trim().isEmpty()) {
+            return null;
+        }
+        return parseAllowList(hostSelectionCandidatesCsv);
+    }
+
+    /**
+     * The inverse of {@link #parseAllowListOrNull}: renders null as "" (inherit), an
+     * empty set as a single comma (a visible, non-blank marker for "explicitly no
+     * restriction" that round-trips back through {@link #parseAllowListOrNull} to an
+     * empty - not null - set), and anything else as the plain comma-separated form.
+     */
+    public static String toAllowListString(Set<String> hosts) {
+        if (hosts == null) {
+            return "";
+        }
+        if (hosts.isEmpty()) {
+            return ",";
+        }
+        return toCsv(hosts);
+    }
+
+    /**
+     * Resolves a template/build-step's {@code hostSelectionMode} against its cloud's
+     * default: blank/null defers to {@code cloudDefault}; {@link #HOST_SELECTION_MODE_NONE}
+     * explicitly disables host selection regardless of the cloud default; any other
+     * value (a real mode) wins outright.
+     */
+    public static String resolveMode(String cloudDefault, String override) {
+        if (override == null || override.isEmpty()) {
+            return cloudDefault;
+        }
+        if (HOST_SELECTION_MODE_NONE.equals(override)) {
+            return "";
+        }
+        return override;
+    }
+
+    /**
+     * Resolves a template/build-step's {@code hostSelectionCandidates} against its
+     * cloud's default: null (never set at this level) defers to {@code cloudDefault};
+     * any explicitly-set value - including an empty set, meaning "explicitly no
+     * restriction" - wins outright.
+     */
+    public static Set<String> resolveCandidates(Set<String> cloudDefault, Set<String> override) {
+        return override != null ? override : cloudDefault;
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/config.jelly
@@ -43,6 +43,14 @@
                  description="0 - the connection is kept alive indefinitely.">
             <f:textbox clazz="number" default="0"/>
         </f:entry>
+
+        <f:entry title="${%Default Host Selection Mode}" field="hostSelectionMode">
+            <f:select/>
+        </f:entry>
+
+        <f:entry title="${%Default Host Selection Candidates}" field="hostSelectionCandidatesAsString">
+            <f:textbox/>
+        </f:entry>
     </f:advanced>
 
     <f:entry title="${%Templates}" description="${%List of Master VMs to be cloned as slaves}">

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-hostSelectionCandidatesAsString.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-hostSelectionCandidatesAsString.html
@@ -1,0 +1,19 @@
+<div>
+  (Optional) Default host allow-list for every template and build step that uses this
+  cloud and doesn't set its own candidate list, restricting what "Default Host Selection
+  Mode" above (or a template/build-step's own mode) is allowed to consider,
+  e.g. <tt>esx01.example.com, esx02.example.com, esx03.example.com</tt>.
+  <p>
+  In a pipeline or Configuration-as-Code YAML, you can use this same comma-separated
+  string form under the name <tt>hostSelectionCandidatesAsString</tt>, or instead give a
+  native list of individual host names under <tt>hostSelectionCandidates</tt> - whichever
+  is more convenient; both end up stored the same way.
+  </p>
+  <p>
+  A template or build step using this cloud can override this default with its own
+  candidate list - including setting it to a single comma (<tt>,</tt>), which explicitly
+  means "no restriction at this call site" and is treated differently from leaving it
+  blank (which inherits this cloud-wide default).
+  </p>
+  Leave blank if there is no cloud-wide restriction to apply by default.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-hostSelectionMode.html
@@ -1,0 +1,25 @@
+<div>
+  (Optional) Default automatic host-selection mode for every template and build step that
+  uses this cloud and doesn't set its own <tt>hostSelectionMode</tt>.
+  <p>
+  Which hosts a service account can actually write to, and whether DRS is enabled and
+  licensed, are properties of this vCenter environment - not of any one template or
+  build step - so setting a default here avoids having to repeat the same choice on
+  every template/pipeline call using this cloud.
+  </p>
+  <ul>
+    <li><b>(none)</b> - no cloud-wide default; unless a template/build-step sets its own
+    mode, clones are placed wherever vCenter's own default logic decides (unchanged
+    legacy behaviour).</li>
+    <li><b>Least loaded host</b> - no DRS license required; see the same option's
+    description on the Clone/Deploy build steps or vSphere templates for details.</li>
+    <li><b>DRS recommendation</b> - requires DRS enabled and licensed on the cluster;
+    falls back to "Least loaded host" if unavailable. See the same option's description
+    on the Clone/Deploy build steps or vSphere templates for details.</li>
+  </ul>
+  <p>
+  A template or build step using this cloud can override this default with its own
+  <tt>hostSelectionMode</tt>, or set it to <tt>NONE</tt> to explicitly disable host
+  selection for just that call site regardless of this cloud-wide default.
+  </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-vsDescription.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloud/help-vsDescription.html
@@ -1,1 +1,1 @@
-<div>A brief, human readable name for this vSphere Cloud. This value will be displayed in a combobox when creating slaves for this cloud.</div>
+<div>A brief, human readable name for this vSphere Cloud. This value will be displayed in a combobox when creating slaves for this cloud or used as the <tt>serverName</tt> in the pipeline steps.</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -24,7 +24,7 @@
             <f:entry title="${%Linked Clone}" field="linkedClone">
                 <f:checkbox/>
             </f:entry>
-            <f:validateButton title="${%Check Template}" progress="${%Testing...}" method="testCloneParameters" with="vsHost,allowUntrustedCertificate,credentialsId,masterImageName,linkedClone,useSnapshot,snapshotName"/>
+            <f:validateButton title="${%Check Template}" progress="${%Testing...}" method="testCloneParameters" with="vsHost,allowUntrustedCertificate,credentialsId,masterImageName,linkedClone,useSnapshot,snapshotName,targetHost,candidateHosts"/>
 
             <f:entry title="${%Cluster}" field="cluster">
                 <f:textbox/>
@@ -39,6 +39,18 @@
             </f:entry>
 
             <f:entry title="${%Folder}" field="folder">
+                <f:textbox/>
+            </f:entry>
+
+            <f:entry title="${%Target Host}" field="targetHost">
+                <f:textbox/>
+            </f:entry>
+
+            <f:entry title="${%Host Selection Mode}" field="hostSelectionMode">
+                <f:select/>
+            </f:entry>
+
+            <f:entry title="${%Candidate Hosts}" field="candidateHosts">
                 <f:textbox/>
             </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/config.jelly
@@ -24,7 +24,7 @@
             <f:entry title="${%Linked Clone}" field="linkedClone">
                 <f:checkbox/>
             </f:entry>
-            <f:validateButton title="${%Check Template}" progress="${%Testing...}" method="testCloneParameters" with="vsHost,allowUntrustedCertificate,credentialsId,masterImageName,linkedClone,useSnapshot,snapshotName,targetHost,candidateHosts"/>
+            <f:validateButton title="${%Check Template}" progress="${%Testing...}" method="testCloneParameters" with="vsHost,allowUntrustedCertificate,credentialsId,masterImageName,linkedClone,useSnapshot,snapshotName,targetHost,hostSelectionCandidatesAsString"/>
 
             <f:entry title="${%Cluster}" field="cluster">
                 <f:textbox/>
@@ -50,7 +50,7 @@
                 <f:select/>
             </f:entry>
 
-            <f:entry title="${%Candidate Hosts}" field="candidateHosts">
+            <f:entry title="${%Host Selection Candidates}" field="hostSelectionCandidatesAsString">
                 <f:textbox/>
             </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-candidateHosts.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-candidateHosts.html
@@ -1,0 +1,18 @@
+<div>
+  (Optional) Comma-separated list of host names that "Host Selection Mode" above is
+  allowed to consider, e.g. <tt>esx01.example.com, esx02.example.com, esx03.example.com</tt>.
+  Any other host in the cluster is ignored by automatic selection, even if it would
+  otherwise be a better pick.
+  <p>
+  Not every host visible in a cluster is necessarily usable by the vCenter account
+  running this connection - a vCenter admin may restrict provisioning permission to a
+  subset of hosts. This field is the only mechanism this plugin offers to keep automatic
+  selection within permitted hosts.
+  </p>
+  <p>
+  This is <b>not verified live against actual vCenter permissions</b>: an incorrect entry,
+  or a host the account cannot actually write to, only surfaces as a vCenter-side error
+  when a clone is attempted, not as a validation error here.
+  </p>
+  Leave blank to consider every (usable) host in the configured cluster.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionCandidatesAsString.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionCandidatesAsString.html
@@ -21,5 +21,13 @@
   or a host the account cannot actually write to, only surfaces as a vCenter-side error
   when a clone is attempted, not as a validation error here.
   </p>
-  Leave blank to consider every (usable) host in the configured cluster.
+  <p>
+  Leaving this <b>blank</b> inherits the cloud's own default candidate list (configured
+  on the vSphere Cloud itself), if any; if the cloud has no default either, every
+  (usable) host in the configured cluster is a candidate. To explicitly override the
+  cloud's default to "no restriction" for this call site specifically - rather than
+  inheriting whatever the cloud has configured - enter a single comma (<tt>,</tt>): this
+  is not blank, so it is treated as a deliberate override, but it still parses to zero
+  host names.
+  </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionCandidatesAsString.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionCandidatesAsString.html
@@ -4,6 +4,13 @@
   Any other host in the cluster is ignored by automatic selection, even if it would
   otherwise be a better pick.
   <p>
+  In a pipeline or Configuration-as-Code YAML, you can use this same comma-separated
+  string form under the name <tt>hostSelectionCandidatesAsString</tt>, or instead give a
+  native list of individual host names under <tt>hostSelectionCandidates</tt>, e.g.
+  <tt>hostSelectionCandidates: ['esx01.example.com', 'esx02.example.com']</tt> - whichever is
+  more convenient. Both end up stored the same way; use only one of the two per template/step.
+  </p>
+  <p>
   Not every host visible in a cluster is necessarily usable by the vCenter account
   running this connection - a vCenter admin may restrict provisioning permission to a
   subset of hosts. This field is the only mechanism this plugin offers to keep automatic

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionMode.html
@@ -1,0 +1,35 @@
+<div>
+  (Optional) How to automatically pick a placement host when "Host" above is left blank.
+  Without this, clones land wherever vCenter's own default logic decides - in practice,
+  often the same host the source VM/template is registered on, which can unbalance load
+  across a cluster over time.
+  <p>
+  Which mode fits best depends on your VMware license/edition and local preference, not
+  just mechanics:
+  </p>
+  <ul>
+    <li>
+      <b>(none)</b> - unchanged legacy behaviour. No requirements. Safe default; existing
+      jobs/pipelines are unaffected unless you opt in.
+    </li>
+    <li>
+      <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each
+      candidate host (see "Candidate Hosts" below) and picks the least loaded one itself.
+      No DRS feature or license is needed, so it works on Essentials/Standard editions,
+      or on a cluster with DRS turned off. It does not know about VMware's own affinity/
+      anti-affinity rules, HA reservations, or storage placement policies. Good default
+      for quick/simple setups, or whenever DRS isn't available/licensed.
+    </li>
+    <li>
+      <b>DRS recommendation</b> - asks vCenter's own DRS engine for a placement
+      recommendation, restricted to the candidate hosts. This honours the cluster's real
+      DRS/HA/affinity/storage policies, but <b>requires DRS to be enabled and licensed on
+      the cluster</b> (vSphere Enterprise Plus, or an equivalent edition/license). On
+      editions or clusters without DRS, the request fails and this plugin automatically
+      falls back to "Least loaded host" behaviour (logged as a warning), rather than
+      failing the build. Recommended for enterprise environments that already rely on
+      DRS, so that Jenkins agent placement follows the same policy as everything else in
+      the cluster.
+    </li>
+  </ul>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionMode.html
@@ -9,8 +9,15 @@
   </p>
   <ul>
     <li>
-      <b>(none)</b> - unchanged legacy behaviour. No requirements. Safe default; existing
-      jobs/pipelines are unaffected unless you opt in.
+      <b>(none)</b> - inherits this cloud's own default <tt>hostSelectionMode</tt>
+      (configured on the vSphere Cloud itself), if any; if the cloud has no default
+      either, this is unchanged legacy behaviour. Safe default; existing jobs/pipelines
+      are unaffected unless something opts in.
+    </li>
+    <li>
+      <b>Explicitly none</b> - overrides the cloud's default (if any) to force
+      unchanged legacy behaviour for this call site specifically, even when the cloud
+      itself has a default mode configured.
     </li>
     <li>
       <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-hostSelectionMode.html
@@ -14,11 +14,11 @@
     </li>
     <li>
       <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each
-      candidate host (see "Candidate Hosts" below) and picks the least loaded one itself.
-      No DRS feature or license is needed, so it works on Essentials/Standard editions,
-      or on a cluster with DRS turned off. It does not know about VMware's own affinity/
-      anti-affinity rules, HA reservations, or storage placement policies. Good default
-      for quick/simple setups, or whenever DRS isn't available/licensed.
+      candidate host (see "Host Selection Candidates" below) and picks the least loaded
+      one itself. No DRS feature or license is needed, so it works on Essentials/Standard
+      editions, or on a cluster with DRS turned off. It does not know about VMware's own
+      affinity/anti-affinity rules, HA reservations, or storage placement policies. Good
+      default for quick/simple setups, or whenever DRS isn't available/licensed.
     </li>
     <li>
       <b>DRS recommendation</b> - asks vCenter's own DRS engine for a placement
@@ -32,4 +32,10 @@
       the cluster.
     </li>
   </ul>
+  <p>
+  Either automatic mode needs a cluster to search: if "Cluster" above is left blank, this
+  plugin will use the only cluster in the vCenter's inventory if there is exactly one:
+  otherwise (no clusters, or more than one) it logs a message and falls back to letting
+  vCenter decide, exactly as if this field had been left blank.
+  </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-targetHost.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-targetHost.html
@@ -1,0 +1,20 @@
+<div>
+  (Optional) Pins every clone made from this template to this specific ESXi host, by
+  name, within the configured cluster.
+  <p>
+  When set, this always wins over "Host Selection Mode" below, which is then ignored.
+  Leave blank to use vCenter's own default placement (unchanged legacy behaviour), or
+  to let "Host Selection Mode" choose automatically.
+  </p>
+  <p>
+  Works on any vSphere edition/license, and with any permission setup - including a
+  service account that can only write to a single host. This is usually the right
+  choice for small/test labs, or whenever you want full manual control over where
+  agents land.
+  </p>
+  Example: <tt>esx-rack3-host07.example.com</tt>
+  <p>
+  This value is also exposed as the <tt>targetHost</tt> variable for use in
+  "GuestInfo Properties" below.
+  </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
@@ -64,5 +64,19 @@ limitations under the License.
 
   <!-- TODO: How can we specify an optional Map<String,String> to set extraConfigParameters? -->
 
-  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,sourceName,clone,resourcePool,cluster"/>
+  <f:advanced>
+    <f:entry title="${%Host}" field="host">
+      <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Host Selection Mode}" field="hostSelectionMode">
+      <f:select/>
+    </f:entry>
+
+    <f:entry title="${%Candidate Hosts}" field="candidateHosts">
+      <f:textbox/>
+    </f:entry>
+  </f:advanced>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,sourceName,clone,resourcePool,cluster,host,candidateHosts"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/config.jelly
@@ -73,10 +73,10 @@ limitations under the License.
       <f:select/>
     </f:entry>
 
-    <f:entry title="${%Candidate Hosts}" field="candidateHosts">
+    <f:entry title="${%Host Selection Candidates}" field="hostSelectionCandidatesAsString">
       <f:textbox/>
     </f:entry>
   </f:advanced>
 
-  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,sourceName,clone,resourcePool,cluster,host,candidateHosts"/>
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,sourceName,clone,resourcePool,cluster,host,hostSelectionCandidatesAsString"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-candidateHosts.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-candidateHosts.html
@@ -1,0 +1,18 @@
+<div>
+  (Optional) Comma-separated list of host names that "Host Selection Mode" above is
+  allowed to consider, e.g. <tt>esx01.example.com, esx02.example.com, esx03.example.com</tt>.
+  Any other host in the cluster is ignored by automatic selection, even if it would
+  otherwise be a better pick.
+  <p>
+  Not every host visible in a cluster is necessarily usable by the vCenter account
+  running this connection - a vCenter admin may restrict provisioning permission to a
+  subset of hosts. This field is the only mechanism this plugin offers to keep automatic
+  selection within permitted hosts.
+  </p>
+  <p>
+  This is <b>not verified live against actual vCenter permissions</b>: an incorrect entry,
+  or a host the account cannot actually write to, only surfaces as a vCenter-side error
+  when a clone is attempted, not as a validation error here.
+  </p>
+  Leave blank to consider every (usable) host in the configured cluster.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-host.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-host.html
@@ -1,0 +1,16 @@
+<div>
+  (Optional) Pins the clone to this specific ESXi host, by name, within the configured
+  cluster.
+  <p>
+  When set, this always wins over "Host Selection Mode" below, which is then ignored.
+  Leave blank to use vCenter's own default placement (unchanged legacy behaviour), or
+  to let "Host Selection Mode" choose automatically.
+  </p>
+  <p>
+  Works on any vSphere edition/license, and with any permission setup - including a
+  service account that can only write to a single host. This is usually the right
+  choice for small/test labs, or whenever you want full manual control over where
+  clones land.
+  </p>
+  Example: <tt>esx-rack3-host07.example.com</tt>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionCandidatesAsString.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionCandidatesAsString.html
@@ -21,5 +21,13 @@
   or a host the account cannot actually write to, only surfaces as a vCenter-side error
   when a clone is attempted, not as a validation error here.
   </p>
-  Leave blank to consider every (usable) host in the configured cluster.
+  <p>
+  Leaving this <b>blank</b> inherits the cloud's own default candidate list (configured
+  on the vSphere Cloud itself), if any; if the cloud has no default either, every
+  (usable) host in the configured cluster is a candidate. To explicitly override the
+  cloud's default to "no restriction" for this call site specifically - rather than
+  inheriting whatever the cloud has configured - enter a single comma (<tt>,</tt>): this
+  is not blank, so it is treated as a deliberate override, but it still parses to zero
+  host names.
+  </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionCandidatesAsString.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionCandidatesAsString.html
@@ -4,6 +4,13 @@
   Any other host in the cluster is ignored by automatic selection, even if it would
   otherwise be a better pick.
   <p>
+  In a pipeline or Configuration-as-Code YAML, you can use this same comma-separated
+  string form under the name <tt>hostSelectionCandidatesAsString</tt>, or instead give a
+  native list of individual host names under <tt>hostSelectionCandidates</tt>, e.g.
+  <tt>hostSelectionCandidates: ['esx01.example.com', 'esx02.example.com']</tt> - whichever is
+  more convenient. Both end up stored the same way; use only one of the two per template/step.
+  </p>
+  <p>
   Not every host visible in a cluster is necessarily usable by the vCenter account
   running this connection - a vCenter admin may restrict provisioning permission to a
   subset of hosts. This field is the only mechanism this plugin offers to keep automatic

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionMode.html
@@ -1,0 +1,35 @@
+<div>
+  (Optional) How to automatically pick a placement host when "Host" above is left blank.
+  Without this, clones land wherever vCenter's own default logic decides - in practice,
+  often the same host the source VM/template is registered on, which can unbalance load
+  across a cluster over time.
+  <p>
+  Which mode fits best depends on your VMware license/edition and local preference, not
+  just mechanics:
+  </p>
+  <ul>
+    <li>
+      <b>(none)</b> - unchanged legacy behaviour. No requirements. Safe default; existing
+      jobs/pipelines are unaffected unless you opt in.
+    </li>
+    <li>
+      <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each
+      candidate host (see "Candidate Hosts" below) and picks the least loaded one itself.
+      No DRS feature or license is needed, so it works on Essentials/Standard editions,
+      or on a cluster with DRS turned off. It does not know about VMware's own affinity/
+      anti-affinity rules, HA reservations, or storage placement policies. Good default
+      for quick/simple setups, or whenever DRS isn't available/licensed.
+    </li>
+    <li>
+      <b>DRS recommendation</b> - asks vCenter's own DRS engine for a placement
+      recommendation, restricted to the candidate hosts. This honours the cluster's real
+      DRS/HA/affinity/storage policies, but <b>requires DRS to be enabled and licensed on
+      the cluster</b> (vSphere Enterprise Plus, or an equivalent edition/license). On
+      editions or clusters without DRS, the request fails and this plugin automatically
+      falls back to "Least loaded host" behaviour (logged as a warning), rather than
+      failing the build. Recommended for enterprise environments that already rely on
+      DRS, so that Jenkins agent placement follows the same policy as everything else in
+      the cluster.
+    </li>
+  </ul>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionMode.html
@@ -9,8 +9,15 @@
   </p>
   <ul>
     <li>
-      <b>(none)</b> - unchanged legacy behaviour. No requirements. Safe default; existing
-      jobs/pipelines are unaffected unless you opt in.
+      <b>(none)</b> - inherits this cloud's own default <tt>hostSelectionMode</tt>
+      (configured on the vSphere Cloud itself), if any; if the cloud has no default
+      either, this is unchanged legacy behaviour. Safe default; existing jobs/pipelines
+      are unaffected unless something opts in.
+    </li>
+    <li>
+      <b>Explicitly none</b> - overrides the cloud's default (if any) to force
+      unchanged legacy behaviour for this call site specifically, even when the cloud
+      itself has a default mode configured.
     </li>
     <li>
       <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Clone/help-hostSelectionMode.html
@@ -14,11 +14,11 @@
     </li>
     <li>
       <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each
-      candidate host (see "Candidate Hosts" below) and picks the least loaded one itself.
-      No DRS feature or license is needed, so it works on Essentials/Standard editions,
-      or on a cluster with DRS turned off. It does not know about VMware's own affinity/
-      anti-affinity rules, HA reservations, or storage placement policies. Good default
-      for quick/simple setups, or whenever DRS isn't available/licensed.
+      candidate host (see "Host Selection Candidates" below) and picks the least loaded
+      one itself. No DRS feature or license is needed, so it works on Essentials/Standard
+      editions, or on a cluster with DRS turned off. It does not know about VMware's own
+      affinity/anti-affinity rules, HA reservations, or storage placement policies. Good
+      default for quick/simple setups, or whenever DRS isn't available/licensed.
     </li>
     <li>
       <b>DRS recommendation</b> - asks vCenter's own DRS engine for a placement
@@ -32,4 +32,10 @@
       the cluster.
     </li>
   </ul>
+  <p>
+  Either automatic mode needs a cluster to search: if "Cluster" above is left blank, this
+  plugin will use the only cluster in the vCenter's inventory if there is exactly one:
+  otherwise (no clusters, or more than one) it logs a message and falls back to letting
+  vCenter decide, exactly as if this field had been left blank.
+  </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
@@ -59,10 +59,10 @@ limitations under the License.
       <f:select/>
     </f:entry>
 
-    <f:entry title="${%Candidate Hosts}" field="candidateHosts">
+    <f:entry title="${%Host Selection Candidates}" field="hostSelectionCandidatesAsString">
       <f:textbox/>
     </f:entry>
   </f:advanced>
 
-  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,template,clone,resourcePool,cluster,host,candidateHosts"/>
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,template,clone,resourcePool,cluster,host,hostSelectionCandidatesAsString"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/config.jelly
@@ -50,5 +50,19 @@ limitations under the License.
     </f:entry>
   </f:optionalBlock>
 
-  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,template,clone,resourcePool,cluster"/>
+  <f:advanced>
+    <f:entry title="${%Host}" field="host">
+      <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Host Selection Mode}" field="hostSelectionMode">
+      <f:select/>
+    </f:entry>
+
+    <f:entry title="${%Candidate Hosts}" field="candidateHosts">
+      <f:textbox/>
+    </f:entry>
+  </f:advanced>
+
+  <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,template,clone,resourcePool,cluster,host,candidateHosts"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-candidateHosts.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-candidateHosts.html
@@ -1,0 +1,18 @@
+<div>
+  (Optional) Comma-separated list of host names that "Host Selection Mode" above is
+  allowed to consider, e.g. <tt>esx01.example.com, esx02.example.com, esx03.example.com</tt>.
+  Any other host in the cluster is ignored by automatic selection, even if it would
+  otherwise be a better pick.
+  <p>
+  Not every host visible in a cluster is necessarily usable by the vCenter account
+  running this connection - a vCenter admin may restrict provisioning permission to a
+  subset of hosts. This field is the only mechanism this plugin offers to keep automatic
+  selection within permitted hosts.
+  </p>
+  <p>
+  This is <b>not verified live against actual vCenter permissions</b>: an incorrect entry,
+  or a host the account cannot actually write to, only surfaces as a vCenter-side error
+  when a clone is attempted, not as a validation error here.
+  </p>
+  Leave blank to consider every (usable) host in the configured cluster.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-host.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-host.html
@@ -1,0 +1,16 @@
+<div>
+  (Optional) Pins the clone to this specific ESXi host, by name, within the configured
+  cluster.
+  <p>
+  When set, this always wins over "Host Selection Mode" below, which is then ignored.
+  Leave blank to use vCenter's own default placement (unchanged legacy behaviour), or
+  to let "Host Selection Mode" choose automatically.
+  </p>
+  <p>
+  Works on any vSphere edition/license, and with any permission setup - including a
+  service account that can only write to a single host. This is usually the right
+  choice for small/test labs, or whenever you want full manual control over where
+  clones land.
+  </p>
+  Example: <tt>esx-rack3-host07.example.com</tt>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionCandidatesAsString.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionCandidatesAsString.html
@@ -21,5 +21,13 @@
   or a host the account cannot actually write to, only surfaces as a vCenter-side error
   when a clone is attempted, not as a validation error here.
   </p>
-  Leave blank to consider every (usable) host in the configured cluster.
+  <p>
+  Leaving this <b>blank</b> inherits the cloud's own default candidate list (configured
+  on the vSphere Cloud itself), if any; if the cloud has no default either, every
+  (usable) host in the configured cluster is a candidate. To explicitly override the
+  cloud's default to "no restriction" for this call site specifically - rather than
+  inheriting whatever the cloud has configured - enter a single comma (<tt>,</tt>): this
+  is not blank, so it is treated as a deliberate override, but it still parses to zero
+  host names.
+  </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionCandidatesAsString.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionCandidatesAsString.html
@@ -4,6 +4,13 @@
   Any other host in the cluster is ignored by automatic selection, even if it would
   otherwise be a better pick.
   <p>
+  In a pipeline or Configuration-as-Code YAML, you can use this same comma-separated
+  string form under the name <tt>hostSelectionCandidatesAsString</tt>, or instead give a
+  native list of individual host names under <tt>hostSelectionCandidates</tt>, e.g.
+  <tt>hostSelectionCandidates: ['esx01.example.com', 'esx02.example.com']</tt> - whichever is
+  more convenient. Both end up stored the same way; use only one of the two per template/step.
+  </p>
+  <p>
   Not every host visible in a cluster is necessarily usable by the vCenter account
   running this connection - a vCenter admin may restrict provisioning permission to a
   subset of hosts. This field is the only mechanism this plugin offers to keep automatic

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionMode.html
@@ -1,0 +1,35 @@
+<div>
+  (Optional) How to automatically pick a placement host when "Host" above is left blank.
+  Without this, clones land wherever vCenter's own default logic decides - in practice,
+  often the same host the source VM/template is registered on, which can unbalance load
+  across a cluster over time.
+  <p>
+  Which mode fits best depends on your VMware license/edition and local preference, not
+  just mechanics:
+  </p>
+  <ul>
+    <li>
+      <b>(none)</b> - unchanged legacy behaviour. No requirements. Safe default; existing
+      jobs/pipelines are unaffected unless you opt in.
+    </li>
+    <li>
+      <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each
+      candidate host (see "Candidate Hosts" below) and picks the least loaded one itself.
+      No DRS feature or license is needed, so it works on Essentials/Standard editions,
+      or on a cluster with DRS turned off. It does not know about VMware's own affinity/
+      anti-affinity rules, HA reservations, or storage placement policies. Good default
+      for quick/simple setups, or whenever DRS isn't available/licensed.
+    </li>
+    <li>
+      <b>DRS recommendation</b> - asks vCenter's own DRS engine for a placement
+      recommendation, restricted to the candidate hosts. This honours the cluster's real
+      DRS/HA/affinity/storage policies, but <b>requires DRS to be enabled and licensed on
+      the cluster</b> (vSphere Enterprise Plus, or an equivalent edition/license). On
+      editions or clusters without DRS, the request fails and this plugin automatically
+      falls back to "Least loaded host" behaviour (logged as a warning), rather than
+      failing the build. Recommended for enterprise environments that already rely on
+      DRS, so that Jenkins agent placement follows the same policy as everything else in
+      the cluster.
+    </li>
+  </ul>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionMode.html
@@ -9,8 +9,15 @@
   </p>
   <ul>
     <li>
-      <b>(none)</b> - unchanged legacy behaviour. No requirements. Safe default; existing
-      jobs/pipelines are unaffected unless you opt in.
+      <b>(none)</b> - inherits this cloud's own default <tt>hostSelectionMode</tt>
+      (configured on the vSphere Cloud itself), if any; if the cloud has no default
+      either, this is unchanged legacy behaviour. Safe default; existing jobs/pipelines
+      are unaffected unless something opts in.
+    </li>
+    <li>
+      <b>Explicitly none</b> - overrides the cloud's default (if any) to force
+      unchanged legacy behaviour for this call site specifically, even when the cloud
+      itself has a default mode configured.
     </li>
     <li>
       <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionMode.html
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/Deploy/help-hostSelectionMode.html
@@ -14,11 +14,11 @@
     </li>
     <li>
       <b>Least loaded host</b> - this plugin reads current CPU/memory usage for each
-      candidate host (see "Candidate Hosts" below) and picks the least loaded one itself.
-      No DRS feature or license is needed, so it works on Essentials/Standard editions,
-      or on a cluster with DRS turned off. It does not know about VMware's own affinity/
-      anti-affinity rules, HA reservations, or storage placement policies. Good default
-      for quick/simple setups, or whenever DRS isn't available/licensed.
+      candidate host (see "Host Selection Candidates" below) and picks the least loaded
+      one itself. No DRS feature or license is needed, so it works on Essentials/Standard
+      editions, or on a cluster with DRS turned off. It does not know about VMware's own
+      affinity/anti-affinity rules, HA reservations, or storage placement policies. Good
+      default for quick/simple setups, or whenever DRS isn't available/licensed.
     </li>
     <li>
       <b>DRS recommendation</b> - asks vCenter's own DRS engine for a placement
@@ -32,4 +32,10 @@
       the cluster.
     </li>
   </ul>
+  <p>
+  Either automatic mode needs a cluster to search: if "Cluster" above is left blank, this
+  plugin will use the only cluster in the vCenter's inventory if there is exactly one:
+  otherwise (no clusters, or more than one) it logs a message and falls back to letting
+  vCenter decide, exactly as if this field had been left blank.
+  </p>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/CloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/CloneTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.vSphereCloud;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -102,5 +103,50 @@ class CloneTest {
         step.setHostSelectionCandidatesAsString("esx01.example.com, esx02.example.com");
 
         assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
+    }
+
+    @Test
+    void setHostSelectionCandidatesAsStringBlankMeansInherit() throws Exception {
+        Clone step = new Clone("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", false, null, null, null, null, null);
+
+        step.setHostSelectionCandidatesAsString("");
+
+        assertThat(step.getHostSelectionCandidates(), nullValue());
+    }
+
+    @Test
+    void setHostSelectionCandidatesAsStringCommaExplicitlyOverridesToEmpty() throws Exception {
+        Clone step = new Clone("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", false, null, null, null, null, null);
+
+        step.setHostSelectionCandidatesAsString(",");
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of()));
+        assertThat(step.getHostSelectionCandidatesAsString(), is(","));
+    }
+
+    @Test
+    void hostSelectionModeNoneIsStoredVerbatim() throws Exception {
+        // Translation of "NONE" into "no selection" happens only in
+        // VSphereHostSelection.resolveMode at perform-time, not in storage.
+        Clone step = new Clone("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", false, null, null, null, null, null);
+
+        step.setHostSelectionMode("NONE");
+
+        assertThat(step.getHostSelectionMode(), is("NONE"));
+    }
+
+    @Test
+    void sourceCloudCanBeSetAndRetrieved() throws Exception {
+        Clone step = new Clone("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", false, null, null, null, null, null);
+        assertThat(step.getSourceCloud(), nullValue());
+
+        vSphereCloud cloud = new vSphereCloud(null, "my-vcenter", 0, 0, null);
+        step.setSourceCloud(cloud);
+
+        assertThat(step.getSourceCloud(), is(cloud));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/CloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/CloneTest.java
@@ -1,0 +1,71 @@
+package org.jenkinsci.plugins.vsphere.builders;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Verifies the optional host-placement fields ({@code host}, {@code hostSelectionMode},
+ * {@code candidateHosts}) are wired up the same way a Groovy pipeline step invocation
+ * would bind them (named-parameter {@link DescribableModel#instantiate}), and that
+ * omitting them entirely preserves the pre-existing behaviour of this build step.
+ */
+@WithJenkins
+class CloneTest {
+
+    private static Map<String, Object> baseArgs() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("sourceName", "linux-template");
+        args.put("clone", "new-vm");
+        args.put("linkedClone", false);
+        args.put("resourcePool", "Resources");
+        args.put("cluster", "my-cluster");
+        args.put("datastore", "");
+        args.put("folder", "");
+        args.put("powerOn", false);
+        return args;
+    }
+
+    @Test
+    void hostPlacementFieldsAreKnownDataBoundParameters() {
+        // Guards against a regression of the "Unknown parameter" warning that pipeline
+        // authors would otherwise hit when passing these fields.
+        DescribableModel<Clone> model = DescribableModel.of(Clone.class);
+        assertThat(model.getParameter("host"), notNullValue());
+        assertThat(model.getParameter("hostSelectionMode"), notNullValue());
+        assertThat(model.getParameter("candidateHosts"), notNullValue());
+    }
+
+    @Test
+    void hostPlacementFieldsDefaultToNullWhenOmitted() throws Exception {
+        // Backward compatibility: existing jobs/pipelines that don't mention these
+        // fields must behave exactly as before (no host restriction of any kind).
+        Clone step = DescribableModel.of(Clone.class).instantiate(baseArgs());
+
+        assertThat(step.getHost(), nullValue());
+        assertThat(step.getHostSelectionMode(), nullValue());
+        assertThat(step.getCandidateHosts(), nullValue());
+    }
+
+    @Test
+    void hostPlacementFieldsAreHonouredWhenSet() throws Exception {
+        Map<String, Object> args = baseArgs();
+        args.put("host", "esx01.example.com");
+        args.put("hostSelectionMode", "LEAST_LOADED");
+        args.put("candidateHosts", "esx01.example.com, esx02.example.com");
+
+        Clone step = DescribableModel.of(Clone.class).instantiate(args);
+
+        assertThat(step.getHost(), is("esx01.example.com"));
+        assertThat(step.getHostSelectionMode(), is("LEAST_LOADED"));
+        assertThat(step.getCandidateHosts(), is("esx01.example.com, esx02.example.com"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/CloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/CloneTest.java
@@ -1,7 +1,9 @@
 package org.jenkinsci.plugins.vsphere.builders;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.junit.jupiter.api.Test;
@@ -14,7 +16,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Verifies the optional host-placement fields ({@code host}, {@code hostSelectionMode},
- * {@code candidateHosts}) are wired up the same way a Groovy pipeline step invocation
+ * {@code hostSelectionCandidates}) are wired up the same way a Groovy pipeline step invocation
  * would bind them (named-parameter {@link DescribableModel#instantiate}), and that
  * omitting them entirely preserves the pre-existing behaviour of this build step.
  */
@@ -41,7 +43,8 @@ class CloneTest {
         DescribableModel<Clone> model = DescribableModel.of(Clone.class);
         assertThat(model.getParameter("host"), notNullValue());
         assertThat(model.getParameter("hostSelectionMode"), notNullValue());
-        assertThat(model.getParameter("candidateHosts"), notNullValue());
+        assertThat(model.getParameter("hostSelectionCandidates"), notNullValue());
+        assertThat(model.getParameter("hostSelectionCandidatesAsString"), notNullValue());
     }
 
     @Test
@@ -52,7 +55,29 @@ class CloneTest {
 
         assertThat(step.getHost(), nullValue());
         assertThat(step.getHostSelectionMode(), nullValue());
-        assertThat(step.getCandidateHosts(), nullValue());
+        assertThat(step.getHostSelectionCandidates(), nullValue());
+        assertThat(step.getHostSelectionCandidatesAsString(), is(""));
+    }
+
+    @Test
+    void hostSelectionCandidatesAsStringAcceptsACommaSeparatedString() throws Exception {
+        Map<String, Object> args = baseArgs();
+        args.put("hostSelectionCandidatesAsString", "esx01.example.com, esx02.example.com");
+
+        Clone step = DescribableModel.of(Clone.class).instantiate(args);
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
+        assertThat(step.getHostSelectionCandidatesAsString(), is("esx01.example.com, esx02.example.com"));
+    }
+
+    @Test
+    void hostSelectionCandidatesAcceptsAFlatList() throws Exception {
+        Map<String, Object> args = baseArgs();
+        args.put("hostSelectionCandidates", List.of("esx01.example.com", "esx02.example.com"));
+
+        Clone step = DescribableModel.of(Clone.class).instantiate(args);
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
     }
 
     @Test
@@ -60,12 +85,22 @@ class CloneTest {
         Map<String, Object> args = baseArgs();
         args.put("host", "esx01.example.com");
         args.put("hostSelectionMode", "LEAST_LOADED");
-        args.put("candidateHosts", "esx01.example.com, esx02.example.com");
+        args.put("hostSelectionCandidates", List.of("esx01.example.com", "esx02.example.com"));
 
         Clone step = DescribableModel.of(Clone.class).instantiate(args);
 
         assertThat(step.getHost(), is("esx01.example.com"));
         assertThat(step.getHostSelectionMode(), is("LEAST_LOADED"));
-        assertThat(step.getCandidateHosts(), is("esx01.example.com, esx02.example.com"));
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
+    }
+
+    @Test
+    void setHostSelectionCandidatesAsStringUpdatesTheCanonicalSet() throws Exception {
+        Clone step = new Clone("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", false, null, null, null, null, null);
+
+        step.setHostSelectionCandidatesAsString("esx01.example.com, esx02.example.com");
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/DeployTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/DeployTest.java
@@ -1,7 +1,9 @@
 package org.jenkinsci.plugins.vsphere.builders;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.junit.jupiter.api.Test;
@@ -14,7 +16,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Verifies the optional host-placement fields ({@code host}, {@code hostSelectionMode},
- * {@code candidateHosts}) are wired up the same way a Groovy pipeline step invocation
+ * {@code hostSelectionCandidates}) are wired up the same way a Groovy pipeline step invocation
  * would bind them (named-parameter {@link DescribableModel#instantiate}), and that
  * omitting them entirely preserves the pre-existing behaviour of this build step.
  */
@@ -39,7 +41,8 @@ class DeployTest {
         DescribableModel<Deploy> model = DescribableModel.of(Deploy.class);
         assertThat(model.getParameter("host"), notNullValue());
         assertThat(model.getParameter("hostSelectionMode"), notNullValue());
-        assertThat(model.getParameter("candidateHosts"), notNullValue());
+        assertThat(model.getParameter("hostSelectionCandidates"), notNullValue());
+        assertThat(model.getParameter("hostSelectionCandidatesAsString"), notNullValue());
     }
 
     @Test
@@ -48,7 +51,29 @@ class DeployTest {
 
         assertThat(step.getHost(), nullValue());
         assertThat(step.getHostSelectionMode(), nullValue());
-        assertThat(step.getCandidateHosts(), nullValue());
+        assertThat(step.getHostSelectionCandidates(), nullValue());
+        assertThat(step.getHostSelectionCandidatesAsString(), is(""));
+    }
+
+    @Test
+    void hostSelectionCandidatesAsStringAcceptsACommaSeparatedString() throws Exception {
+        Map<String, Object> args = baseArgs();
+        args.put("hostSelectionCandidatesAsString", "esx01.example.com, esx02.example.com");
+
+        Deploy step = DescribableModel.of(Deploy.class).instantiate(args);
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
+        assertThat(step.getHostSelectionCandidatesAsString(), is("esx01.example.com, esx02.example.com"));
+    }
+
+    @Test
+    void hostSelectionCandidatesAcceptsAFlatList() throws Exception {
+        Map<String, Object> args = baseArgs();
+        args.put("hostSelectionCandidates", List.of("esx01.example.com", "esx02.example.com"));
+
+        Deploy step = DescribableModel.of(Deploy.class).instantiate(args);
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
     }
 
     @Test
@@ -56,12 +81,22 @@ class DeployTest {
         Map<String, Object> args = baseArgs();
         args.put("host", "esx01.example.com");
         args.put("hostSelectionMode", "DRS_RECOMMENDED");
-        args.put("candidateHosts", "esx01.example.com, esx02.example.com");
+        args.put("hostSelectionCandidates", List.of("esx01.example.com", "esx02.example.com"));
 
         Deploy step = DescribableModel.of(Deploy.class).instantiate(args);
 
         assertThat(step.getHost(), is("esx01.example.com"));
         assertThat(step.getHostSelectionMode(), is("DRS_RECOMMENDED"));
-        assertThat(step.getCandidateHosts(), is("esx01.example.com, esx02.example.com"));
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
+    }
+
+    @Test
+    void setHostSelectionCandidatesAsStringUpdatesTheCanonicalSet() throws Exception {
+        Deploy step = new Deploy("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", "", null, false);
+
+        step.setHostSelectionCandidatesAsString("esx01.example.com, esx02.example.com");
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/DeployTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/DeployTest.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.vsphere.builders;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Verifies the optional host-placement fields ({@code host}, {@code hostSelectionMode},
+ * {@code candidateHosts}) are wired up the same way a Groovy pipeline step invocation
+ * would bind them (named-parameter {@link DescribableModel#instantiate}), and that
+ * omitting them entirely preserves the pre-existing behaviour of this build step.
+ */
+@WithJenkins
+class DeployTest {
+
+    private static Map<String, Object> baseArgs() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("template", "linux-template");
+        args.put("clone", "new-vm");
+        args.put("linkedClone", false);
+        args.put("resourcePool", "Resources");
+        args.put("cluster", "my-cluster");
+        args.put("datastore", "");
+        args.put("folder", "");
+        args.put("powerOn", false);
+        return args;
+    }
+
+    @Test
+    void hostPlacementFieldsAreKnownDataBoundParameters() {
+        DescribableModel<Deploy> model = DescribableModel.of(Deploy.class);
+        assertThat(model.getParameter("host"), notNullValue());
+        assertThat(model.getParameter("hostSelectionMode"), notNullValue());
+        assertThat(model.getParameter("candidateHosts"), notNullValue());
+    }
+
+    @Test
+    void hostPlacementFieldsDefaultToNullWhenOmitted() throws Exception {
+        Deploy step = DescribableModel.of(Deploy.class).instantiate(baseArgs());
+
+        assertThat(step.getHost(), nullValue());
+        assertThat(step.getHostSelectionMode(), nullValue());
+        assertThat(step.getCandidateHosts(), nullValue());
+    }
+
+    @Test
+    void hostPlacementFieldsAreHonouredWhenSet() throws Exception {
+        Map<String, Object> args = baseArgs();
+        args.put("host", "esx01.example.com");
+        args.put("hostSelectionMode", "DRS_RECOMMENDED");
+        args.put("candidateHosts", "esx01.example.com, esx02.example.com");
+
+        Deploy step = DescribableModel.of(Deploy.class).instantiate(args);
+
+        assertThat(step.getHost(), is("esx01.example.com"));
+        assertThat(step.getHostSelectionMode(), is("DRS_RECOMMENDED"));
+        assertThat(step.getCandidateHosts(), is("esx01.example.com, esx02.example.com"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/DeployTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/DeployTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.vSphereCloud;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -98,5 +99,48 @@ class DeployTest {
         step.setHostSelectionCandidatesAsString("esx01.example.com, esx02.example.com");
 
         assertThat(step.getHostSelectionCandidates(), is(Set.of("esx01.example.com", "esx02.example.com")));
+    }
+
+    @Test
+    void setHostSelectionCandidatesAsStringBlankMeansInherit() throws Exception {
+        Deploy step = new Deploy("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", "", null, false);
+
+        step.setHostSelectionCandidatesAsString("");
+
+        assertThat(step.getHostSelectionCandidates(), nullValue());
+    }
+
+    @Test
+    void setHostSelectionCandidatesAsStringCommaExplicitlyOverridesToEmpty() throws Exception {
+        Deploy step = new Deploy("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", "", null, false);
+
+        step.setHostSelectionCandidatesAsString(",");
+
+        assertThat(step.getHostSelectionCandidates(), is(Set.of()));
+        assertThat(step.getHostSelectionCandidatesAsString(), is(","));
+    }
+
+    @Test
+    void hostSelectionModeNoneIsStoredVerbatim() throws Exception {
+        Deploy step = new Deploy("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", "", null, false);
+
+        step.setHostSelectionMode("NONE");
+
+        assertThat(step.getHostSelectionMode(), is("NONE"));
+    }
+
+    @Test
+    void sourceCloudCanBeSetAndRetrieved() throws Exception {
+        Deploy step = new Deploy("linux-template", "new-vm", false, "Resources", "my-cluster",
+                "", "", "", null, false);
+        assertThat(step.getSourceCloud(), nullValue());
+
+        vSphereCloud cloud = new vSphereCloud(null, "my-vcenter", 0, 0, null);
+        step.setSourceCloud(cloud);
+
+        assertThat(step.getSourceCloud(), is(cloud));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import java.util.List;
+import java.util.Set;
 import org.jenkinsci.plugins.vSphereCloud;
 import org.jenkinsci.plugins.vSphereCloudSlaveTemplate;
 import org.jenkinsci.plugins.vsphere.RunOnceCloudRetentionStrategy;
@@ -87,17 +88,28 @@ class ConfigurationAsCodeTest {
         vSphereCloudSlaveTemplate template = cloud.getTemplates().get(0);
         assertThat(template.getTargetHost(), is(nullValue()));
         assertThat(template.getHostSelectionMode(), is(nullValue()));
-        assertThat(template.getCandidateHosts(), is(nullValue()));
+        assertThat(template.getHostSelectionCandidates(), is(nullValue()));
     }
 
     @Test
     @ConfiguredWithCode("configuration-as-code-with-host-selection.yml")
     void should_load_host_selection_configuration_from_yaml(JenkinsConfiguredWithCodeRule r) {
+        // This fixture gives hostSelectionCandidates as a plain comma-separated scalar string.
         vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
         vSphereCloudSlaveTemplate template = cloud.getTemplates().get(0);
         assertThat(template.getTargetHost(), is("esx01.company.example"));
         assertThat(template.getHostSelectionMode(), is("LEAST_LOADED"));
-        assertThat(template.getCandidateHosts(), is("esx01.company.example, esx02.company.example"));
+        assertThat(template.getHostSelectionCandidates(), is(Set.of("esx01.company.example", "esx02.company.example")));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-with-host-selection-list.yml")
+    void should_load_candidate_hosts_given_as_a_yaml_list(JenkinsConfiguredWithCodeRule r) {
+        // Same as above, but hostSelectionCandidates is given as a native YAML list instead of a
+        // comma-separated scalar string - both forms must be accepted equivalently.
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        vSphereCloudSlaveTemplate template = cloud.getTemplates().get(0);
+        assertThat(template.getHostSelectionCandidates(), is(Set.of("esx01.company.example", "esx02.company.example")));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
@@ -85,10 +85,30 @@ class ConfigurationAsCodeTest {
         // Backward compatibility: templates defined before this feature existed must
         // keep behaving exactly as before (no host restriction of any kind).
         vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        assertThat(cloud.getHostSelectionMode(), is(nullValue()));
+        assertThat(cloud.getHostSelectionCandidates(), is(nullValue()));
         vSphereCloudSlaveTemplate template = cloud.getTemplates().get(0);
         assertThat(template.getTargetHost(), is(nullValue()));
         assertThat(template.getHostSelectionMode(), is(nullValue()));
         assertThat(template.getHostSelectionCandidates(), is(nullValue()));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-with-cloud-host-selection-defaults.yml")
+    void should_load_cloud_level_host_selection_defaults_from_yaml(JenkinsConfiguredWithCodeRule r) {
+        // This fixture gives hostSelectionCandidates as a plain comma-separated scalar string,
+        // set directly on the cloud (not on any template).
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        assertThat(cloud.getHostSelectionMode(), is("LEAST_LOADED"));
+        assertThat(cloud.getHostSelectionCandidates(), is(Set.of("esx01.company.example", "esx02.company.example")));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-with-cloud-host-selection-defaults-list.yml")
+    void should_load_cloud_level_host_selection_candidates_given_as_a_yaml_list(JenkinsConfiguredWithCodeRule r) {
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        assertThat(cloud.getHostSelectionMode(), is("DRS_RECOMMENDED"));
+        assertThat(cloud.getHostSelectionCandidates(), is(Set.of("esx01.company.example", "esx02.company.example")));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/ConfigurationAsCodeTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @WithJenkinsConfiguredWithCode
@@ -75,6 +76,28 @@ class ConfigurationAsCodeTest {
         assertThat(cloud.getSessionMaxAgeSecs(), is(3600));
         assertThat(cloud.getSessionMaxUses(), is(500));
         assertThat(cloud.getPoolIdleTimeoutSecs(), is(300));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void host_selection_fields_are_unset_by_default_when_not_specified_in_yaml(JenkinsConfiguredWithCodeRule r) {
+        // Backward compatibility: templates defined before this feature existed must
+        // keep behaving exactly as before (no host restriction of any kind).
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        vSphereCloudSlaveTemplate template = cloud.getTemplates().get(0);
+        assertThat(template.getTargetHost(), is(nullValue()));
+        assertThat(template.getHostSelectionMode(), is(nullValue()));
+        assertThat(template.getCandidateHosts(), is(nullValue()));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-with-host-selection.yml")
+    void should_load_host_selection_configuration_from_yaml(JenkinsConfiguredWithCodeRule r) {
+        vSphereCloud cloud = (vSphereCloud) r.jenkins.clouds.get(0);
+        vSphereCloudSlaveTemplate template = cloud.getTemplates().get(0);
+        assertThat(template.getTargetHost(), is("esx01.company.example"));
+        assertThat(template.getHostSelectionMode(), is("LEAST_LOADED"));
+        assertThat(template.getCandidateHosts(), is("esx01.company.example, esx02.company.example"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelectionTest.java
@@ -1,0 +1,115 @@
+package org.jenkinsci.plugins.vsphere.tools;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.jenkinsci.plugins.vsphere.tools.VSphereHostSelection.HostCandidate;
+import org.junit.jupiter.api.Test;
+
+class VSphereHostSelectionTest {
+
+    @Test
+    void parseAllowListReturnsEmptySetForNullOrBlank() {
+        assertThat(VSphereHostSelection.parseAllowList(null), empty());
+        assertThat(VSphereHostSelection.parseAllowList(""), empty());
+        assertThat(VSphereHostSelection.parseAllowList("   "), empty());
+    }
+
+    @Test
+    void parseAllowListTrimsAndDropsEmptyEntries() {
+        Set<String> allowList = VSphereHostSelection.parseAllowList(" esx1 , esx2,, esx3 ");
+        assertThat(allowList, contains("esx1", "esx2", "esx3"));
+    }
+
+    @Test
+    void filterCandidatesExcludesDisconnectedAndMaintenanceHosts() {
+        HostCandidate connected = candidate("esx1", true, false, 1000, 2000, 1000, 2000);
+        HostCandidate disconnected = candidate("esx2", false, false, 1000, 2000, 1000, 2000);
+        HostCandidate inMaintenance = candidate("esx3", true, true, 1000, 2000, 1000, 2000);
+
+        List<HostCandidate> filtered = VSphereHostSelection.filterCandidates(
+                List.of(connected, disconnected, inMaintenance), Set.of());
+
+        assertThat(filtered, contains(connected));
+    }
+
+    @Test
+    void filterCandidatesHonoursNonEmptyAllowList() {
+        HostCandidate esx1 = candidate("esx1", true, false, 1000, 2000, 1000, 2000);
+        HostCandidate esx2 = candidate("esx2", true, false, 1000, 2000, 1000, 2000);
+
+        List<HostCandidate> filtered = VSphereHostSelection.filterCandidates(
+                List.of(esx1, esx2), Set.of("esx2"));
+
+        assertThat(filtered, contains(esx2));
+    }
+
+    @Test
+    void filterCandidatesWithEmptyAllowListConsidersAllUsableHosts() {
+        HostCandidate esx1 = candidate("esx1", true, false, 1000, 2000, 1000, 2000);
+        HostCandidate esx2 = candidate("esx2", true, false, 1000, 2000, 1000, 2000);
+
+        List<HostCandidate> filtered = VSphereHostSelection.filterCandidates(
+                List.of(esx1, esx2), Set.of());
+
+        assertThat(filtered, contains(esx1, esx2));
+    }
+
+    @Test
+    void pickLeastLoadedPicksLowerCpuAndMemoryUsageFraction() {
+        // esx1 at 80% cpu, esx2 at 20% cpu -> esx2 should win
+        HostCandidate busy = candidate("esx1", true, false, 1600, 2000, 400, 2000);
+        HostCandidate idle = candidate("esx2", true, false, 400, 2000, 400, 2000);
+
+        HostCandidate winner = VSphereHostSelection.pickLeastLoaded(List.of(busy, idle));
+
+        assertThat(winner, is(idle));
+    }
+
+    @Test
+    void pickLeastLoadedUsesTheMoreConstrainedOfCpuOrMemory() {
+        // esx1: low cpu but very high memory usage -> should lose to esx2 which is moderate on both
+        HostCandidate memoryBound = candidate("esx1", true, false, 100, 2000, 1900, 2000);
+        HostCandidate balanced = candidate("esx2", true, false, 1000, 2000, 1000, 2000);
+
+        HostCandidate winner = VSphereHostSelection.pickLeastLoaded(List.of(memoryBound, balanced));
+
+        assertThat(winner, is(balanced));
+    }
+
+    @Test
+    void pickLeastLoadedExcludesHostsWithMissingStats() {
+        HostCandidate noStats = candidate("esx1", true, false, null, 2000, null, 2000);
+        HostCandidate withStats = candidate("esx2", true, false, 1000, 2000, 1000, 2000);
+
+        HostCandidate winner = VSphereHostSelection.pickLeastLoaded(List.of(noStats, withStats));
+
+        assertThat(winner, is(withStats));
+    }
+
+    @Test
+    void pickLeastLoadedReturnsNullWhenNoCandidateHasStats() {
+        HostCandidate noStats1 = candidate("esx1", true, false, null, 2000, null, 2000);
+        HostCandidate noStats2 = candidate("esx2", true, false, null, 2000, null, 2000);
+
+        HostCandidate winner = VSphereHostSelection.pickLeastLoaded(List.of(noStats1, noStats2));
+
+        assertThat(winner, nullValue());
+    }
+
+    @Test
+    void pickLeastLoadedReturnsNullForEmptyList() {
+        assertThat(VSphereHostSelection.pickLeastLoaded(List.of()), nullValue());
+    }
+
+    private static HostCandidate candidate(String name, boolean connected, boolean inMaintenanceMode,
+            Integer cpuUsageMhz, int cpuCapacityMhz, Integer memUsageMB, long memCapacityMB) {
+        return new HostCandidate(name, connected, inMaintenanceMode, cpuUsageMhz, cpuCapacityMhz, memUsageMB, memCapacityMB);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelectionTest.java
@@ -32,6 +32,70 @@ class VSphereHostSelectionTest {
     }
 
     @Test
+    void parseAllowListOrNullReturnsNullForBlankOrWhitespace() {
+        assertThat(VSphereHostSelection.parseAllowListOrNull(null), nullValue());
+        assertThat(VSphereHostSelection.parseAllowListOrNull(""), nullValue());
+        assertThat(VSphereHostSelection.parseAllowListOrNull("   "), nullValue());
+    }
+
+    @Test
+    void parseAllowListOrNullReturnsEmptySetForACommaSentinel() {
+        // Not blank after trim, so it survives as an explicit "override to nothing",
+        // distinct from a field that was never set at all.
+        assertThat(VSphereHostSelection.parseAllowListOrNull(","), is(Set.of()));
+    }
+
+    @Test
+    void parseAllowListOrNullParsesRealValuesNormally() {
+        assertThat(VSphereHostSelection.parseAllowListOrNull("esx1, esx2"), is(Set.of("esx1", "esx2")));
+    }
+
+    @Test
+    void toAllowListStringRoundTripsThroughParseAllowListOrNull() {
+        assertThat(VSphereHostSelection.parseAllowListOrNull(VSphereHostSelection.toAllowListString(null)), nullValue());
+        assertThat(VSphereHostSelection.parseAllowListOrNull(VSphereHostSelection.toAllowListString(Set.of())), is(Set.of()));
+        assertThat(VSphereHostSelection.parseAllowListOrNull(VSphereHostSelection.toAllowListString(Set.of("esx1", "esx2"))),
+                is(Set.of("esx1", "esx2")));
+    }
+
+    @Test
+    void toAllowListStringUsesACommaForExplicitlyEmpty() {
+        assertThat(VSphereHostSelection.toAllowListString(null), is(""));
+        assertThat(VSphereHostSelection.toAllowListString(Set.of()), is(","));
+    }
+
+    @Test
+    void resolveModeInheritsCloudDefaultWhenOverrideIsBlank() {
+        assertThat(VSphereHostSelection.resolveMode("LEAST_LOADED", null), is("LEAST_LOADED"));
+        assertThat(VSphereHostSelection.resolveMode("LEAST_LOADED", ""), is("LEAST_LOADED"));
+        assertThat(VSphereHostSelection.resolveMode(null, null), nullValue());
+    }
+
+    @Test
+    void resolveModeNoneExplicitlyDisablesRegardlessOfCloudDefault() {
+        assertThat(VSphereHostSelection.resolveMode("LEAST_LOADED", "NONE"), is(""));
+        assertThat(VSphereHostSelection.resolveMode(null, "NONE"), is(""));
+    }
+
+    @Test
+    void resolveModeExplicitOverrideWins() {
+        assertThat(VSphereHostSelection.resolveMode("LEAST_LOADED", "DRS_RECOMMENDED"), is("DRS_RECOMMENDED"));
+        assertThat(VSphereHostSelection.resolveMode(null, "LEAST_LOADED"), is("LEAST_LOADED"));
+    }
+
+    @Test
+    void resolveCandidatesInheritsCloudDefaultWhenOverrideIsNull() {
+        assertThat(VSphereHostSelection.resolveCandidates(Set.of("esx1"), null), is(Set.of("esx1")));
+        assertThat(VSphereHostSelection.resolveCandidates(null, null), nullValue());
+    }
+
+    @Test
+    void resolveCandidatesExplicitOverrideWinsEvenWhenEmpty() {
+        assertThat(VSphereHostSelection.resolveCandidates(Set.of("esx1"), Set.of()), is(Set.of()));
+        assertThat(VSphereHostSelection.resolveCandidates(Set.of("esx1"), Set.of("esx2")), is(Set.of("esx2")));
+    }
+
+    @Test
     void parseAllowListReturnsEmptySetForNullOrBlank() {
         assertThat(VSphereHostSelection.parseAllowList(null), empty());
         assertThat(VSphereHostSelection.parseAllowList(""), empty());

--- a/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/tools/VSphereHostSelectionTest.java
@@ -15,6 +15,23 @@ import org.junit.jupiter.api.Test;
 class VSphereHostSelectionTest {
 
     @Test
+    void toCsvReturnsEmptyStringForNullOrEmpty() {
+        assertThat(VSphereHostSelection.toCsv(null), is(""));
+        assertThat(VSphereHostSelection.toCsv(List.of()), is(""));
+    }
+
+    @Test
+    void toCsvJoinsWithCommaAndSpace() {
+        assertThat(VSphereHostSelection.toCsv(List.of("esx1", "esx2", "esx3")), is("esx1, esx2, esx3"));
+    }
+
+    @Test
+    void parseAllowListAndToCsvRoundTrip() {
+        Set<String> parsed = VSphereHostSelection.parseAllowList(" esx1 , esx2, esx3 ");
+        assertThat(VSphereHostSelection.toCsv(parsed), is("esx1, esx2, esx3"));
+    }
+
+    @Test
     void parseAllowListReturnsEmptySetForNullOrBlank() {
         assertThat(VSphereHostSelection.parseAllowList(null), empty());
         assertThat(VSphereHostSelection.parseAllowList(""), empty());
@@ -37,6 +54,15 @@ class VSphereHostSelectionTest {
                 List.of(connected, disconnected, inMaintenance), Set.of());
 
         assertThat(filtered, contains(connected));
+    }
+
+    @Test
+    void filterCandidatesTreatsNullAllowListAsNoRestriction() {
+        HostCandidate esx1 = candidate("esx1", true, false, 1000, 2000, 1000, 2000);
+
+        List<HostCandidate> filtered = VSphereHostSelection.filterCandidates(List.of(esx1), null);
+
+        assertThat(filtered, contains(esx1));
     }
 
     @Test

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-cloud-host-selection-defaults-list.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-cloud-host-selection-defaults-list.yml
@@ -1,0 +1,13 @@
+jenkins:
+  systemMessage: "Hello World"
+  clouds:
+    - vSphere:
+        instanceCap: 0
+        maxOnlineSlaves: 0
+        hostSelectionMode: "DRS_RECOMMENDED"
+        hostSelectionCandidates:
+          - "esx01.company.example"
+          - "esx02.company.example"
+        vsConnectionConfig:
+          vsHost: "https://company-vsphere"
+        vsDescription: "Cloud Host Selection Defaults List Test vSphere"

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-cloud-host-selection-defaults.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-cloud-host-selection-defaults.yml
@@ -1,0 +1,11 @@
+jenkins:
+  systemMessage: "Hello World"
+  clouds:
+    - vSphere:
+        instanceCap: 0
+        maxOnlineSlaves: 0
+        hostSelectionMode: "LEAST_LOADED"
+        hostSelectionCandidatesAsString: "esx01.company.example, esx02.company.example"
+        vsConnectionConfig:
+          vsHost: "https://company-vsphere"
+        vsDescription: "Cloud Host Selection Defaults Test vSphere"

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-host-selection-list.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-host-selection-list.yml
@@ -28,10 +28,12 @@ jenkins:
             saveFailure: false
             targetHost: "esx01.company.example"
             hostSelectionMode: "LEAST_LOADED"
-            hostSelectionCandidatesAsString: "esx01.company.example, esx02.company.example"
+            hostSelectionCandidates:
+              - "esx01.company.example"
+              - "esx02.company.example"
             templateInstanceCap: 5
             useSnapshot: true
             waitForVMTools: true
         vsConnectionConfig:
           vsHost: "https://company-vsphere"
-        vsDescription: "Host Selection Test vSphere"
+        vsDescription: "Host Selection List Test vSphere"

--- a/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-host-selection.yml
+++ b/src/test/resources/org/jenkinsci/plugins/vsphere/tools/configuration-as-code-with-host-selection.yml
@@ -1,0 +1,37 @@
+jenkins:
+  systemMessage: "Hello World"
+  clouds:
+    - vSphere:
+        instanceCap: 100
+        maxOnlineSlaves: 0
+        templates:
+          - cloneNamePrefix: "windows-"
+            cluster: "Company"
+            datastore: "Company-FMD-01"
+            folder: "Company/Jenkins agents/Linked clones"
+            forceVMLaunch: true
+            labelString: "windows vsphere"
+            launchDelay: 60
+            launcher:
+              jnlp:
+                tunnel: "jenkins:"
+            limitedRunCount: 1
+            linkedClone: true
+            masterImageName: "windows-server-2019"
+            mode: EXCLUSIVE
+            numberOfExecutors: 1
+            remoteFS: "C:/jenkins"
+            resourcePool: "Resources"
+            retentionStrategy:
+              vsphereRunOnceCloud:
+                idleMinutes: 2
+            saveFailure: false
+            targetHost: "esx01.company.example"
+            hostSelectionMode: "LEAST_LOADED"
+            candidateHosts: "esx01.company.example, esx02.company.example"
+            templateInstanceCap: 5
+            useSnapshot: true
+            waitForVMTools: true
+        vsConnectionConfig:
+          vsHost: "https://company-vsphere"
+        vsDescription: "Host Selection Test vSphere"


### PR DESCRIPTION
Clones previously landed wherever vCenter's default placement chose (often the same host as the source template), causing load imbalance across a cluster.

This PR adds optional `host`/`hostSelectionMode`/`candidateHosts` fields to the `Clone` and `Deploy` build steps, and wires up the existing but previously-unused `targetHost` field on vSphere cloud templates, so a clone can be pinned to a named host or auto-placed via a least-loaded heuristic or vCenter's own DRS recommendation, restricted to a permission-filtered candidate list. All new fields default to blank/`null`, preserving existing behaviour unless opted in.

This relies on features already handled by yavijava-9.x, which this plugin can use since PR #174.

Code prepared by Claude AI under my supervision and design inputs.

### Testing done

Unit tests added.

Planning some runs against an actual ESXi farm.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
