### PR TITLE
[JENKINS-76493] Fix NullPointerException when deleting a VM snapshot

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/tools/VSphere.java
@@ -833,8 +833,10 @@ public class VSphere {
         try {
             Task task;
             if (snap!=null) {
-                //Does not delete subtree; Implicitly consolidates disk
-                task = snap.removeSnapshot_Task(false);
+                //Does not delete subtree; consolidates the disk, which the API did implicitly while the flag was
+                //omitted - it has to be explicit now, as the single-argument overload delegates a null Boolean
+                //that the SDK unboxes
+                task = snap.removeSnapshot_Task(false, Boolean.TRUE);
                 if (!task.waitForTask().equals(Task.SUCCESS)) {
                     throw newVSphereException(task.getTaskInfo(), "Could not delete snapshot");
                 }


### PR DESCRIPTION
# JENKINS-76493 — Fix NullPointerException when deleting a VM snapshot

https://issues.jenkins.io/browse/JENKINS-76493

## Problem

The "Delete a Snapshot" build step fails before the snapshot is removed, so every snapshot-based
workflow that recreates a known-good snapshot is broken.

- **What:** delete a named snapshot of a VM (freestyle build step or `DeleteSnapshot` pipeline step).
- **How it fails:** the build aborts inside the step. Pipeline console output:
  ```
  [vSphere]
  [vSphere] Performing vSphere build step: "Delete a Snapshot"
  [vSphere] Attempting to use server configuration: "vc02zrh2"
  [vSphere] Deleting snapshot "clean-test-env-2204" of VM generic05build-a.lab...
  Cannot invoke "java.lang.Boolean.booleanValue()" because "consolidate" is null
  ```
  The Helpful NullPointerException message (JEP 358) names the culprit: the boxed `Boolean consolidate`
  is `null` and gets unboxed via `booleanValue()`.
- **Expected:** the snapshot is deleted and the build continues.
- Seen with vSphere Plugin 4.563.v2d59e5e96653 on Jenkins 2.578, and reported for 4.530.v1b_68fb_22777c.
- The build step's own `consolidate` option makes no difference: the NPE happens before the separate
  full-VM `consolidateVMDisks_Task()` call is ever reached.

## Root cause

Exposed by the yavijava 6.0.05 → 9.0.2 upgrade (released in 4.530): the regenerated
`VimStub.removeSnapshot_Task` binding changed its `consolidate` parameter from a nullable `Boolean`
to a primitive `boolean`:

```java
// yavijava 6.0.05, VimStub.java:4489
public ManagedObjectReference removeSnapshot_Task(ManagedObjectReference _this, boolean removeChildren, Boolean consolidate)
// yavijava 9.0.2, VimStub.java:5416
public ManagedObjectReference removeSnapshot_Task(ManagedObjectReference _this, boolean removeChildren, boolean consolidate)
```

`VSphere.deleteSnapshot()` calls the single-argument convenience overload
`VirtualMachineSnapshot.removeSnapshot_Task(boolean)`, which delegates a **null** `Boolean`:

```java
// yavijava 9.0.2, com/vmware/vim25/mo/VirtualMachineSnapshot.java:43-48
public Task removeSnapshot_Task(boolean removeChildren) ... {
    return removeSnapshot_Task(removeChildren, null);
}
public Task removeSnapshot_Task(boolean removeChildren, Boolean consolidate) ... {
    return new Task(getServerConnection(), getVimService().removeSnapshot_Task(getMOR(), removeChildren, consolidate));
}
```

Unboxing that `null` for the primitive parameter throws before any request reaches vCenter, so the
snapshot is left in place.

This is the same regression class as JENKINS-76498 (#181), where `revertToSnapshot_Task`'s
`suppressPowerOn` was fixed by passing a non-null `Boolean`. Scanning yavijava 9.0.2 for overloads that
delegate `null` into a primitive stub parameter yields exactly two — `removeSnapshot_Task(boolean)` and
`revertToSnapshot_Task(HostSystem)` — and after #181 the plugin only called the former, so this is the
last remaining site. By contrast `VirtualMachine.revertToCurrentSnapshot_Task(HostSystem)` delegates
`false` rather than `null`, which is why "revert to current snapshot" was never affected.

## Fix

Pass the flag explicitly:

```java
task = snap.removeSnapshot_Task(false, Boolean.TRUE);
```

`Boolean.TRUE` rather than the build step's `consolidate` option, because
`VirtualMachineSnapshot.RemoveSnapshot_Task`'s `consolidate` parameter is optional and
[defaults to `true`](https://developer.broadcom.com/xapis/virtual-infrastructure-json-api/latest/sdk/vim25/release/VirtualMachineSnapshot/moId/RemoveSnapshot_Task/post/)
when omitted. That is what vCenter applied for the pre-4.530 `removeSnapshot_Task(false)` calls (see the
existing "Implicitly consolidates disk" comment), so behaviour is unchanged from before the upgrade. The
build step's `consolidate` option keeps governing only the additional full-VM `consolidateVMDisks_Task()`
call, exactly as before.

## Testing

No new automated test: the failure occurs inside the yavijava SOAP binding, which the plugin has no
mocking infrastructure for (no Mockito test dependency, no mocks in `src/test`), and reaching the call
needs a live `ServiceInstance`. #181 likewise only added data-binding tests rather than covering the NPE
itself.

- Existing test suite passes (`mvn package` on Temurin 21).
- The change is the exact counterpart of the #181 fix: an explicit non-null `Boolean` for a parameter the
  9.x binding now unboxes unconditionally, with the value the API documents as its own default.
