### PR TITLE
Fix the remaining null-unboxing NPEs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java
@@ -216,7 +216,8 @@ public class vSphereCloudLauncher extends DelegatingComputerLauncher {
                             break;
                     }
 
-                    if (waitForVMTools) {
+                    // Null in agent configurations saved before the field existed, as with overrideLaunchSupported
+                    if (Boolean.TRUE.equals(waitForVMTools)) {
                         vSphereCloud.Log(slaveComputer, taskListener, "Waiting for VMTools");
 
                         Calendar target = Calendar.getInstance();

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo.java
@@ -60,6 +60,12 @@ public class ExposeGuestInfo extends VSphereBuildStep implements SimpleBuildStep
         return envVariablePrefix;
     }
 
+    public boolean isWaitForIp4() {
+        // Null whenever the flag was never set: a pipeline step that omits it, or a job configured before
+        // the field existed. Waiting was not an option back then, so that is the compatible answer.
+        return Boolean.TRUE.equals(waitForIp4);
+    }
+
     @Override
     public String getIP() {
         return IP;
@@ -133,7 +139,7 @@ public class ExposeGuestInfo extends VSphereBuildStep implements SimpleBuildStep
         }
         VSphereEnvAction envAction = createGuestInfoEnvAction(vsphereVm, jLogger);
 
-        if (waitForIp4){
+        if (isWaitForIp4()){
             String prefix = resolvedEnvVariablePrefix == null ? envVariablePrefix : resolvedEnvVariablePrefix;
             String machineIP = envAction.data.get(prefix + "_IpAddress");
             while (!ipv4Pattern.matcher(machineIP).find()) {

--- a/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureDisk.java
+++ b/src/main/java/org/jenkinsci/plugins/vsphere/builders/ReconfigureDisk.java
@@ -238,8 +238,10 @@ public class ReconfigureDisk extends ReconfigureStep {
 		map.put(7, true); // Unit number 7 is reserved for the controller
 
 		for (VirtualDevice vmDevice : vm.getConfig().getHardware().getDevice()) {
+			// getControllerKey() is optional in the API, so compare from the controller's own key to keep a
+			// device without one from unboxing null
 			if (vmDevice.getUnitNumber() != null &&
-					(vmDevice.getControllerKey() == controller.getKey() || vmDevice.getKey() == controller.getKey())) {
+					(Integer.valueOf(controller.getKey()).equals(vmDevice.getControllerKey()) || vmDevice.getKey() == controller.getKey())) {
 				map.put(vmDevice.getUnitNumber(), true);
 			}
 		}

--- a/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfo/config.jelly
@@ -25,7 +25,7 @@ limitations under the License.
   </f:entry>
 
   <f:entry title="${%wait For Ip 4?}" field="waitForIp4">
-    <f:checkbox checked="true"/>
+    <f:checkbox default="true"/>
   </f:entry>
 
   <f:validateButton title="${%Check Data}" progress="${%Testing...}" method="testData" with="serverName,vm"/>

--- a/src/test/java/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfoTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vsphere/builders/ExposeGuestInfoTest.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.plugins.vsphere.builders;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@WithJenkins
+class ExposeGuestInfoTest {
+
+    @Test
+    void waitForIp4IsAKnownDataBoundParameter(JenkinsRule r) {
+        DescribableModel<ExposeGuestInfo> model = DescribableModel.of(ExposeGuestInfo.class);
+        assertThat(model.getParameter("waitForIp4"), notNullValue());
+    }
+
+    @Test
+    void waitForIp4DefaultsToFalseWhenOmitted(JenkinsRule r) throws Exception {
+        // A pipeline step that omits the flag, or a job configured before the field existed, leaves the
+        // Boolean null - which must read as "do not wait" rather than throw.
+        Map<String, Object> args = new HashMap<>();
+        args.put("vm", "some-vm");
+        args.put("envVariablePrefix", "VSPHERE");
+
+        ExposeGuestInfo step = DescribableModel.of(ExposeGuestInfo.class).instantiate(args);
+
+        assertThat(step.getVm(), is("some-vm"));
+        assertThat(step.isWaitForIp4(), is(false));
+    }
+
+    @Test
+    void waitForIp4IsHonouredWhenSet(JenkinsRule r) throws Exception {
+        Map<String, Object> args = new HashMap<>();
+        args.put("vm", "some-vm");
+        args.put("envVariablePrefix", "VSPHERE");
+        args.put("waitForIp4", true);
+
+        ExposeGuestInfo step = DescribableModel.of(ExposeGuestInfo.class).instantiate(args);
+
+        assertThat(step.isWaitForIp4(), is(true));
+    }
+}


### PR DESCRIPTION
# Fix the remaining null-unboxing NPEs

Follow-up to #189 (JENKINS-76493) and #181 (JENKINS-76498). Both of those were one shape of bug — a boxed
value that is `null` reaching an implicit unboxing — so rather than guess where else it hides, I enumerated
them: every class in `target/classes` disassembled with `javap -c -l`, each
`booleanValue/intValue/longValue/doubleValue` call mapped back to its source line through the
LineNumberTable. That gives 36 unboxing sites, 33 of which are properly guarded. These are the three that
are not.

None of them come from the yavijava 6.0.05 → 9.0.2 upgrade: of the two SDK overloads that delegate `null`
into a primitive stub parameter (`VirtualMachineSnapshot.removeSnapshot_Task(boolean)` and
`revertToSnapshot_Task(HostSystem)`), the plugin calls neither any more after #181 and #189. These three are
the plugin's own optional values.

## 1. `ExposeGuestInfo.waitForIp4` — reachable from a pipeline today

`waitForIp4` is a `Boolean` that `exposeInfo` unboxes unguarded, so the step throws before doing any work
whenever the flag was never set:

```
Cannot invoke "java.lang.Boolean.booleanValue()" because "this.waitForIp4" is null
```

That happens for a pipeline step declaring only the fields it cares about —
`vSphere buildStep: [$class: 'ExposeGuestInfo', vm: '…', envVariablePrefix: '…'], serverName: '…'`, where
`structs` passes `null` for an omitted `Boolean` — for a job configured before the field was introduced
(5a1eca0), and for a JCasC definition that leaves it out.

Read through `Boolean.TRUE.equals` so an unset flag means "do not wait": that is how the step behaved
before the field existed, and it keeps a caller that never asked to wait out of the (unbounded) IP wait
loop.

The step also had **no getter at all** for the field, so `config.jelly`'s `field="waitForIp4"` had nothing
to bind against — the form could not show the stored value and JCasC could not export it. This adds
`isWaitForIp4()`, and turns the checkbox's hard-coded `checked="true"` into `default="true"`, which keeps
the same default for new steps while letting an existing configuration show what it actually has. Without
that, every save silently switched the flag back on.

Covered by a new `ExposeGuestInfoTest` in the style of `RevertToSnapshotTest`: the parameter stays
data-bound, an omitted flag reads as `false`, an explicit `true` is honoured.

## 2. `ReconfigureDisk.selectUnitNumber` — unboxing an optional device key

`vmDevice.getControllerKey() == controller.getKey()` compares a boxed `Integer` that the API documents as
optional against the controller's primitive `int`, so the comparison unboxes whatever the device reports.
The guard in front of it only checks `getUnitNumber() != null`, so a device that has a unit number without
belonging to a controller fails the whole disk reconfiguration. Comparing from the controller's own key
(`Integer.valueOf(controller.getKey()).equals(...)`) reads a missing device key as "not this controller".

Not reproduced against a live VM — reported as a wrong guard, not as an observed failure.

## 3. `vSphereCloudLauncher` — unboxing `waitForVMTools` on launch

Same shape: a boxed `Boolean` that `readResolve()` never defaults, unboxed while launching an agent, so an
agent configuration saved before the field existed cannot start. `overrideLaunchSupported`, two accessors
down, already guards for exactly this case in `isLaunchSupported()`; this does the same. The public
`getWaitForVMTools()` accessor is left as-is so JCasC round-tripping does not change.

## Testing

- `mvn package` on Temurin 21: `BUILD SUCCESS`, 165 tests green (162 existing + 3 new).
- Re-ran the `javap` scan afterwards: the three sites are gone, and the unboxings that remain in those
  classes are the guarded one in `isLaunchSupported()` and `ReconfigureDisk`'s private `Integer retry`
  parameter, which every caller passes a literal to.
- The `ReconfigureDisk` and launcher paths need a live vCenter and an old agent config respectively, so
  they are argued from the types rather than covered by a test.
